### PR TITLE
feat: Switch chairman model priority to GPT-5.1 primary

### DIFF
--- a/backend/model_registry.py
+++ b/backend/model_registry.py
@@ -32,9 +32,9 @@ FALLBACK_MODELS = {
         'deepseek/deepseek-chat-v3-0324',
     ],
     'chairman': [
-        'anthropic/claude-opus-4.5',
-        'google/gemini-3-pro-preview',
         'openai/gpt-5.1',
+        'google/gemini-3-pro-preview',
+        'anthropic/claude-opus-4.5',
     ],
     'title_generator': [
         'google/gemini-2.5-flash',

--- a/supabase/migrations/20251220000000_model_registry.sql
+++ b/supabase/migrations/20251220000000_model_registry.sql
@@ -103,9 +103,9 @@ INSERT INTO model_registry (role, model_id, display_name, priority, notes) VALUE
 -- Chairman (Stage 3 - synthesizes final response)
 -- Primary model with fallbacks in case of failure
 INSERT INTO model_registry (role, model_id, display_name, priority, notes) VALUES
-('chairman', 'anthropic/claude-opus-4.5', 'Claude Opus 4.5', 0, 'Primary chairman - best synthesis'),
+('chairman', 'openai/gpt-5.1', 'GPT-5.1', 0, 'Primary chairman - best synthesis'),
 ('chairman', 'google/gemini-3-pro-preview', 'Gemini 3 Pro', 1, 'Fallback 1'),
-('chairman', 'openai/gpt-5.1', 'GPT-5.1', 2, 'Fallback 2');
+('chairman', 'anthropic/claude-opus-4.5', 'Claude Opus 4.5', 2, 'Fallback 2');
 
 -- Title Generator (fast, cheap model for generating conversation titles)
 INSERT INTO model_registry (role, model_id, display_name, priority, notes) VALUES


### PR DESCRIPTION
Updated chairman model priority order:
- Primary: openai/gpt-5.1 (was claude-opus-4.5)
- Fallback 1: google/gemini-3-pro-preview (unchanged)
- Fallback 2: anthropic/claude-opus-4.5 (was gpt-5.1)

Changes in:
- Database migration: model_registry chairman seed data
- Backend fallbacks: model_registry.py FALLBACK_MODELS