### PR TITLE
fix(csp): allow Google Fonts in connect-src for service worker

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -29,7 +29,7 @@
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://openrouter.ai https://*.sentry.io https://axcouncil-backend.onrender.com https://*.onrender.com; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://openrouter.ai https://*.sentry.io https://axcouncil-backend.onrender.com https://*.onrender.com https://fonts.googleapis.com https://fonts.gstatic.com; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Adds `https://fonts.googleapis.com` and `https://fonts.gstatic.com` to CSP `connect-src` directive
- Fixes service worker (workbox) failing to cache Google Fonts CSS due to CSP violation

## Problem
The workbox service worker uses `fetch()` to cache Google Fonts, which requires `connect-src` permission. Previously only `style-src` and `font-src` allowed these domains.

## Test plan
- [ ] Deploy to Vercel preview
- [ ] Open browser console - no more CSP violations for fonts.googleapis.com
- [ ] Fonts load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)