### PR TITLE
feat(i18n): Expand translation coverage across UI components

### DIFF
--- a/backend/context_loader.py
+++ b/backend/context_loader.py
@@ -94,7 +94,7 @@ def list_available_businesses(
             # SECURITY: Filter to only companies user has access to
             # First get companies user owns
             owned_result = client.table("companies").select(
-                "id, name, slug, departments(id, name, slug, roles(id, name, slug))"
+                "id, name, slug, departments(id, name, slug, llm_preset, roles(id, name, slug))"
             ).eq("user_id", user_id).execute()
 
             # Then get companies user has department access to
@@ -126,14 +126,14 @@ def list_available_businesses(
                 return {"companies": [], "has_more": False}
 
             result = client.table("companies").select(
-                "id, name, slug, departments(id, name, slug, roles(id, name, slug))"
+                "id, name, slug, departments(id, name, slug, llm_preset, roles(id, name, slug))"
             ).in_("id", paginated_ids[:limit]).execute()  # Only fetch limit, not +1
 
             has_more = len(paginated_ids) > limit
         else:
             # No user filter - return all with pagination (internal use only)
             result = client.table("companies").select(
-                "id, name, slug, departments(id, name, slug, roles(id, name, slug))"
+                "id, name, slug, departments(id, name, slug, llm_preset, roles(id, name, slug))"
             ).range(offset, offset + limit).execute()
 
             # Check if there are more

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import {
   Suspense,
   ComponentType,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import { motion, AnimatePresence } from 'framer-motion';
 import Sidebar from './components/Sidebar';
 import { LandingHero } from './components/landing';
@@ -132,6 +133,7 @@ const generateInitialTitle = (content: string, maxLength = 60): string => {
 const log = logger.scope('App');
 
 function App() {
+  const { t } = useTranslation();
   const {
     user,
     loading: authLoading,
@@ -433,15 +435,15 @@ function App() {
                 });
               return newList;
             });
-            toast.error('Failed to delete conversations');
+            toast.error(t('toasts.deleteConversationsFailed'));
           }
         }
       };
 
       // Show toast with undo action
-      toast(`${conversationsToDelete.length} conversations deleted`, {
+      toast(t('toasts.conversationsDeleted', { count: conversationsToDelete.length }), {
         action: {
-          label: 'Undo',
+          label: t('common.undo'),
           onClick: () => {
             undoClicked = true;
             // Restore conversations at original positions
@@ -459,7 +461,9 @@ function App() {
             if (wasCurrentConversationDeleted && currentConversationId) {
               setCurrentConversationId(currentConversationId);
             }
-            toast.success(`${conversationsToDelete.length} conversations restored`);
+            toast.success(
+              t('toasts.conversationsRestored', { count: conversationsToDelete.length })
+            );
           },
         },
         duration: 5000,

--- a/frontend/src/components/Billing.tsx
+++ b/frontend/src/components/Billing.tsx
@@ -51,7 +51,7 @@ export default function Billing({ onClose }: BillingProps) {
       setSubscription(subData);
     } catch (err) {
       log.error('Failed to load billing data:', err);
-      setError("Couldn't load your billing info. Please try again.");
+      setError(t('billing.loadError'));
     } finally {
       setLoading(false);
     }
@@ -66,8 +66,7 @@ export default function Billing({ onClose }: BillingProps) {
       window.location.href = result.checkout_url;
     } catch (err) {
       log.error('Failed to create checkout:', err);
-      const errorMessage =
-        err instanceof Error ? err.message : 'Something went wrong. Please try again.';
+      const errorMessage = err instanceof Error ? err.message : t('errors.generic');
       setError(errorMessage);
       setCheckoutLoading(null);
     }
@@ -82,8 +81,7 @@ export default function Billing({ onClose }: BillingProps) {
       window.location.href = result.portal_url;
     } catch (err) {
       log.error('Failed to open billing portal:', err);
-      const errorMessage =
-        err instanceof Error ? err.message : "Couldn't open billing portal. Please try again.";
+      const errorMessage = err instanceof Error ? err.message : t('billing.portalError');
       setError(errorMessage);
       setCheckoutLoading(null);
     }
@@ -106,7 +104,7 @@ export default function Billing({ onClose }: BillingProps) {
     return (
       <div className="billing-overlay" onClick={handleOverlayClick}>
         <div className="billing-modal" onClick={(e) => e.stopPropagation()}>
-          <div className="billing-loading">Loading billing information...</div>
+          <div className="billing-loading">{t('billing.loadingBilling')}</div>
         </div>
       </div>
     );
@@ -121,7 +119,7 @@ export default function Billing({ onClose }: BillingProps) {
     <div className="billing-overlay" onClick={handleOverlayClick}>
       <div className="billing-modal" onClick={(e) => e.stopPropagation()}>
         <div className="billing-header">
-          <h2>Subscription Plans</h2>
+          <h2>{t('billing.subscriptionPlans')}</h2>
           <button className="billing-close" onClick={onClose}>
             &times;
           </button>
@@ -131,7 +129,7 @@ export default function Billing({ onClose }: BillingProps) {
 
         {/* Current Usage */}
         <div className="billing-usage">
-          <div className="usage-label">Current Usage</div>
+          <div className="usage-label">{t('billing.currentUsage')}</div>
           <div className="usage-bar-container">
             <div
               className="usage-bar"
@@ -144,8 +142,8 @@ export default function Billing({ onClose }: BillingProps) {
           </div>
           <div className="usage-text">
             {isUnlimited
-              ? `${queriesUsed} queries used (Unlimited)`
-              : `${queriesUsed} / ${queriesLimit} queries this month`}
+              ? t('billing.queriesUsedUnlimited', { count: queriesUsed })
+              : t('billing.queriesUsedMonthly', { used: queriesUsed, limit: queriesLimit })}
           </div>
         </div>
 
@@ -165,7 +163,9 @@ export default function Billing({ onClose }: BillingProps) {
                 key={plan.id}
                 className={`plan-card ${isCurrentPlan ? 'current' : ''} ${plan.id === 'pro' ? 'popular' : ''}`}
               >
-                {plan.id === 'pro' && <div className="popular-badge">Most Popular</div>}
+                {plan.id === 'pro' && (
+                  <div className="popular-badge">{t('billing.mostPopular')}</div>
+                )}
 
                 <div className="plan-name">{plan.name}</div>
                 <div className="plan-price">
@@ -192,16 +192,16 @@ export default function Billing({ onClose }: BillingProps) {
                 <div className="plan-action">
                   {isCurrentPlan ? (
                     <Button variant="outline" disabled>
-                      Current Plan
+                      {t('billing.currentPlan')}
                     </Button>
                   ) : isDowngrade ? (
                     <Button
                       variant="outline"
                       onClick={handleManageSubscription}
                       disabled={checkoutLoading !== null}
-                      title="Cancel subscription to downgrade to Free"
+                      title={t('billing.cancelToDowngrade')}
                     >
-                      {checkoutLoading === 'manage' ? 'Loading...' : 'Downgrade'}
+                      {checkoutLoading === 'manage' ? t('common.loading') : t('billing.downgrade')}
                     </Button>
                   ) : (
                     <Button
@@ -210,10 +210,10 @@ export default function Billing({ onClose }: BillingProps) {
                       disabled={checkoutLoading !== null}
                     >
                       {checkoutLoading === plan.id
-                        ? 'Loading...'
+                        ? t('common.loading')
                         : isUpgrade
-                          ? 'Upgrade'
-                          : 'Subscribe'}
+                          ? t('billing.upgrade')
+                          : t('billing.subscribe')}
                     </Button>
                   )}
                 </div>
@@ -230,13 +230,15 @@ export default function Billing({ onClose }: BillingProps) {
               onClick={handleManageSubscription}
               disabled={checkoutLoading !== null}
             >
-              {checkoutLoading === 'manage' ? 'Loading...' : 'Manage Subscription & Billing'}
+              {checkoutLoading === 'manage'
+                ? t('common.loading')
+                : t('billing.manageSubscriptionBilling')}
             </Button>
           </div>
         )}
 
         <div className="billing-footer">
-          <p>Secure payments powered by Stripe</p>
+          <p>{t('billing.stripePowered')}</p>
         </div>
       </div>
     </div>

--- a/frontend/src/components/chat/FollowUpBar.tsx
+++ b/frontend/src/components/chat/FollowUpBar.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import * as Popover from '@radix-ui/react-popover';
 import { Building2, Users, BookOpen, Zap, Check } from 'lucide-react';
 import { cn } from '../../lib/utils';
@@ -46,6 +47,7 @@ export function FollowUpBar({
   onSelectPlaybooks,
   isLoading = false,
 }: FollowUpBarProps) {
+  const { t } = useTranslation();
   const [deptOpen, setDeptOpen] = useState(false);
   const [roleOpen, setRoleOpen] = useState(false);
   const [playbookOpen, setPlaybookOpen] = useState(false);
@@ -82,7 +84,7 @@ export function FollowUpBar({
   const departmentList = (
     <div className="context-popover-list">
       {departments.length === 0 ? (
-        <div className="context-popover-empty">No departments</div>
+        <div className="context-popover-empty">{t('context.noDepartments')}</div>
       ) : (
         departments.map((dept) => {
           const isSelected = selectedDepartments.includes(dept.id);
@@ -115,7 +117,7 @@ export function FollowUpBar({
   const roleList = (
     <div className="context-popover-list">
       {roles.length === 0 ? (
-        <div className="context-popover-empty">No roles</div>
+        <div className="context-popover-empty">{t('context.noRoles')}</div>
       ) : (
         roles.map((role) => {
           const isSelected = selectedRoles.includes(role.id);
@@ -141,7 +143,7 @@ export function FollowUpBar({
   const playbookList = (
     <div className="context-popover-list">
       {playbooks.length === 0 ? (
-        <div className="context-popover-empty">No playbooks</div>
+        <div className="context-popover-empty">{t('context.noPlaybooks')}</div>
       ) : (
         playbooks.map((pb) => {
           const isSelected = selectedPlaybooks.includes(pb.id);
@@ -229,7 +231,7 @@ export function FollowUpBar({
         {hasDepartments &&
           renderContextButton(
             <Building2 size={16} />,
-            'Departments',
+            t('departments.title'),
             selectedDepartments.length,
             deptOpen,
             setDeptOpen,
@@ -239,7 +241,7 @@ export function FollowUpBar({
         {hasRoles &&
           renderContextButton(
             <Users size={16} />,
-            'Roles',
+            t('roles.title'),
             selectedRoles.length,
             roleOpen,
             setRoleOpen,
@@ -249,7 +251,7 @@ export function FollowUpBar({
         {hasPlaybooks &&
           renderContextButton(
             <BookOpen size={16} />,
-            'Playbooks',
+            t('playbooks.title'),
             selectedPlaybooks.length,
             playbookOpen,
             setPlaybookOpen,
@@ -263,12 +265,10 @@ export function FollowUpBar({
           className={cn('context-icon-btn mode-toggle', chatMode === 'council' && 'council')}
           onClick={() => !disabled && onChatModeChange(chatMode === 'chat' ? 'council' : 'chat')}
           disabled={disabled}
-          aria-label={chatMode === 'chat' ? 'Switch to full council' : 'Switch to quick chat'}
-          title={
-            chatMode === 'chat'
-              ? 'Quick mode (click for council)'
-              : 'Council mode (click for quick)'
+          aria-label={
+            chatMode === 'chat' ? t('chat.tooltips.councilMode') : t('chat.tooltips.chatMode')
           }
+          title={chatMode === 'chat' ? t('chat.tooltips.chatMode') : t('chat.tooltips.councilMode')}
         >
           <Zap size={16} />
         </button>

--- a/frontend/src/components/chat/ModeToggle.tsx
+++ b/frontend/src/components/chat/ModeToggle.tsx
@@ -115,7 +115,7 @@ export function ModeToggle({
                   onValueChange={onSelectDepartments}
                   departments={departments}
                   disabled={isLoading}
-                  placeholder="Departments..."
+                  placeholder={t('departments.selectDepartments')}
                   className="mode-toggle-select"
                 />
               )}
@@ -127,7 +127,7 @@ export function ModeToggle({
                   onValueChange={onSelectRoles}
                   roles={allRoles}
                   disabled={isLoading}
-                  placeholder="Roles..."
+                  placeholder={t('roles.selectRoles')}
                   className="mode-toggle-select"
                 />
               )}
@@ -139,11 +139,11 @@ export function ModeToggle({
                   onValueChange={onSelectPlaybooks}
                   playbooks={playbooks.map((p) => ({
                     id: p.id,
-                    title: p.title ?? p.name ?? 'Untitled',
+                    title: p.title ?? p.name ?? t('common.unknown'),
                     doc_type: p.doc_type ?? p.type ?? 'sop',
                   }))}
                   disabled={isLoading ?? false}
-                  placeholder="Playbooks..."
+                  placeholder={t('playbooks.selectPlaybooks')}
                   className="mode-toggle-select"
                 />
               )}
@@ -157,7 +157,7 @@ export function ModeToggle({
                   onValueChange={(vals: string[]) => onSelectDepartment(vals[0] ?? null)}
                   departments={departments}
                   disabled={isLoading}
-                  placeholder="Department..."
+                  placeholder={t('context.department')}
                   className="mode-toggle-select"
                 />
               )}
@@ -168,7 +168,7 @@ export function ModeToggle({
                   onValueChange={(vals: string[]) => onSelectRole(vals[0] ?? null)}
                   roles={roles}
                   disabled={isLoading}
-                  placeholder="Role..."
+                  placeholder={t('modals.roleName')}
                   className="mode-toggle-select"
                 />
               )}

--- a/frontend/src/components/landing/QuickActionChips.tsx
+++ b/frontend/src/components/landing/QuickActionChips.tsx
@@ -4,52 +4,73 @@
  * Jobs-to-be-done approach: users think in tasks, not org charts.
  */
 
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
-import { PenLine, FileSearch, Rocket, Scale, Users, TrendingUp } from 'lucide-react';
+import { PenLine, FileSearch, Rocket, Scale, Users, TrendingUp, LucideIcon } from 'lucide-react';
 import { springs, interactionStates, staggerDelay } from '../../lib/animations';
 import './QuickActionChips.css';
 
-const QUICK_ACTIONS = [
+interface QuickAction {
+  icon: LucideIcon;
+  labelKey: string;
+  promptKey: string;
+}
+
+const QUICK_ACTION_KEYS = [
   {
     icon: PenLine,
-    label: 'Write a pitch',
-    prompt: 'Help me write a compelling pitch for ',
+    labelKey: 'landing.quickActions.writePitch' as const,
+    promptKey: 'landing.quickActions.writePitchPrompt' as const,
   },
   {
     icon: FileSearch,
-    label: 'Review a document',
-    prompt: 'Please review this document and identify any issues: ',
+    labelKey: 'landing.quickActions.reviewDocument' as const,
+    promptKey: 'landing.quickActions.reviewDocumentPrompt' as const,
   },
   {
     icon: Rocket,
-    label: 'Plan a launch',
-    prompt: 'Help me plan the launch strategy for ',
+    labelKey: 'landing.quickActions.planLaunch' as const,
+    promptKey: 'landing.quickActions.planLaunchPrompt' as const,
   },
   {
     icon: Scale,
-    label: 'Analyze a decision',
-    prompt: 'I need to make a decision about ',
+    labelKey: 'landing.quickActions.analyzeDecision' as const,
+    promptKey: 'landing.quickActions.analyzeDecisionPrompt' as const,
   },
   {
     icon: Users,
-    label: 'Handle a situation',
-    prompt: 'Help me handle this situation: ',
+    labelKey: 'landing.quickActions.handleSituation' as const,
+    promptKey: 'landing.quickActions.handleSituationPrompt' as const,
   },
   {
     icon: TrendingUp,
-    label: 'Improve metrics',
-    prompt: 'How can I improve ',
+    labelKey: 'landing.quickActions.improveMetrics' as const,
+    promptKey: 'landing.quickActions.improveMetricsPrompt' as const,
   },
-];
+] satisfies QuickAction[];
 
 interface QuickActionChipsProps {
   onSelect?: ((prompt: string) => void) | undefined;
 }
 
 export function QuickActionChips({ onSelect }: QuickActionChipsProps) {
+  const { t } = useTranslation();
+
+  // Build translated actions
+  const actions = useMemo(
+    () =>
+      QUICK_ACTION_KEYS.map((action) => ({
+        icon: action.icon,
+        label: t(action.labelKey),
+        prompt: t(action.promptKey),
+      })),
+    [t]
+  );
+
   return (
     <div className="quick-action-chips">
-      {QUICK_ACTIONS.map((action, index) => {
+      {actions.map((action, index) => {
         const Icon = action.icon;
         return (
           <motion.button

--- a/frontend/src/components/mycompany/tabs/MembersTab.tsx
+++ b/frontend/src/components/mycompany/tabs/MembersTab.tsx
@@ -15,6 +15,7 @@
 import { formatDate } from '../../../lib/dateUtils';
 
 import { useState, useEffect, FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
 import { api } from '../../../api';
 import {
   Users,
@@ -80,6 +81,7 @@ export function MembersTab({
   companyId,
   currentUserId, // To identify current user and their role
 }: MembersTabProps) {
+  const { t } = useTranslation();
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -176,7 +178,7 @@ export function MembersTab({
     return (
       <div className="mc-loading">
         <Spinner size={24} />
-        <span>Loading team...</span>
+        <span>{t('mycompany.loadingTeam')}</span>
       </div>
     );
   }
@@ -187,7 +189,7 @@ export function MembersTab({
         <AlertCircle size={20} />
         <span>{error}</span>
         <Button variant="outline" size="sm" onClick={loadData}>
-          Retry
+          {t('common.retry')}
         </Button>
       </div>
     );
@@ -199,14 +201,12 @@ export function MembersTab({
       <div className="mc-members-header">
         <div className="mc-members-count">
           <Users size={18} />
-          <span>
-            {members.length} {members.length === 1 ? 'member' : 'members'}
-          </span>
+          <span>{t('settings.memberCount', { count: members.length })}</span>
         </div>
         {canManageMembers && (
           <Button variant="default" size="sm" onClick={() => setShowAddForm(!showAddForm)}>
             <Plus size={16} />
-            Add Member
+            {t('settings.addMember')}
           </Button>
         )}
       </div>
@@ -219,7 +219,7 @@ export function MembersTab({
               id="mc-new-member-email"
               name="member-email"
               type="email"
-              placeholder="Email address"
+              placeholder={t('settings.emailAddress')}
               value={newEmail}
               onChange={(e) => setNewEmail(e.target.value)}
               className="mc-input"
@@ -282,7 +282,7 @@ export function MembersTab({
                 <div className="mc-member-info">
                   <span className="mc-member-name">
                     {/* Email display requires backend user lookup (auth.users view) */}
-                    {isCurrentUser ? 'You' : `User ${member.user_id.slice(0, 8)}...`}
+                    {isCurrentUser ? t('settings.you') : `User ${member.user_id.slice(0, 8)}...`}
                   </span>
                   <span className="mc-member-role-label" style={{ color: roleConfig.color }}>
                     {roleConfig.label}
@@ -291,7 +291,7 @@ export function MembersTab({
 
                 {/* Joined date */}
                 <div className="mc-member-joined">
-                  Joined {formatDate(member.joined_at || member.created_at)}
+                  {t('mycompany.joined')} {formatDate(member.joined_at || member.created_at)}
                 </div>
 
                 {/* Actions */}
@@ -305,7 +305,7 @@ export function MembersTab({
                       <button
                         className="mc-icon-btn promote"
                         onClick={() => handleChangeRole(member.id, 'admin')}
-                        title="Promote to Admin"
+                        title={t('settings.promoteToAdmin')}
                       >
                         <ChevronUp size={16} />
                       </button>
@@ -314,7 +314,7 @@ export function MembersTab({
                       <button
                         className="mc-icon-btn demote"
                         onClick={() => handleChangeRole(member.id, 'member')}
-                        title="Demote to Member"
+                        title={t('settings.demoteToMember')}
                       >
                         <ChevronDown size={16} />
                       </button>
@@ -323,7 +323,7 @@ export function MembersTab({
                       <button
                         className="mc-icon-btn danger"
                         onClick={() => handleRemoveMember(member.id, member.role)}
-                        title="Remove from team"
+                        title={t('settings.removeFromTeam')}
                       >
                         <Trash2 size={16} />
                       </button>

--- a/frontend/src/components/sidebar/BulkActionBar.tsx
+++ b/frontend/src/components/sidebar/BulkActionBar.tsx
@@ -7,6 +7,7 @@
  * - Touch-friendly button sizes
  */
 
+import { useTranslation } from 'react-i18next';
 import { Trash2 } from 'lucide-react';
 import { Button } from '../ui/button';
 
@@ -23,22 +24,23 @@ export function BulkActionBar({
   onClearSelection,
   onBulkDelete,
 }: BulkActionBarProps) {
+  const { t } = useTranslation();
   if (selectedCount === 0) return null;
 
   return (
-    <div className="bulk-action-bar" role="region" aria-label="Bulk actions">
+    <div className="bulk-action-bar" role="region" aria-label={t('sidebar.bulkActions')}>
       <span className="bulk-count" role="status" aria-live="polite">
-        {selectedCount} selected
+        {t('sidebar.selectedCount', { count: selectedCount })}
       </span>
       <div className="bulk-action-buttons">
         <Button
           variant="ghost"
           size="sm"
           onClick={onClearSelection}
-          aria-label="Cancel selection"
+          aria-label={t('sidebar.cancelSelection')}
           className="bulk-cancel-btn"
         >
-          Cancel
+          {t('common.cancel')}
         </Button>
         <Button
           variant="destructive"
@@ -47,13 +49,13 @@ export function BulkActionBar({
           disabled={isDeleting}
           aria-label={
             isDeleting
-              ? 'Deleting conversations'
-              : `Delete ${selectedCount} conversation${selectedCount !== 1 ? 's' : ''}`
+              ? t('sidebar.deletingConversations')
+              : t('sidebar.deleteConversations', { count: selectedCount })
           }
           className="bulk-delete-btn"
         >
           <Trash2 size={14} aria-hidden="true" />
-          {isDeleting ? 'Deleting...' : 'Delete'}
+          {isDeleting ? t('sidebar.deleting') : t('common.delete')}
         </Button>
       </div>
     </div>

--- a/frontend/src/components/sidebar/ConversationContextMenu.tsx
+++ b/frontend/src/components/sidebar/ConversationContextMenu.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import { Pencil, Star, Archive, ArchiveRestore, Trash2, Download, LucideIcon } from 'lucide-react';
 import type { Conversation } from '../../types';
@@ -50,6 +51,7 @@ export function ConversationContextMenu({
   onDelete,
   onExport,
 }: ConversationContextMenuProps) {
+  const { t } = useTranslation();
   const menuRef = useRef<HTMLDivElement | null>(null);
 
   // Close on Escape and click outside
@@ -105,7 +107,7 @@ export function ConversationContextMenu({
 
   const menuItems: MenuItem[] = [
     {
-      label: 'Rename',
+      label: t('contextMenu.rename'),
       icon: Pencil,
       onClick: () => {
         onRename(conversation);
@@ -113,7 +115,7 @@ export function ConversationContextMenu({
       },
     },
     {
-      label: conversation.is_starred ? 'Remove star' : 'Add star',
+      label: conversation.is_starred ? t('contextMenu.removeStar') : t('contextMenu.addStar'),
       icon: Star,
       onClick: () => {
         onStar(conversation.id, !conversation.is_starred);
@@ -123,7 +125,7 @@ export function ConversationContextMenu({
     },
     { type: 'separator' },
     {
-      label: conversation.is_archived ? 'Unarchive' : 'Archive',
+      label: conversation.is_archived ? t('contextMenu.unarchive') : t('contextMenu.archive'),
       icon: conversation.is_archived ? ArchiveRestore : Archive,
       onClick: () => {
         onArchive(conversation.id, !conversation.is_archived);
@@ -133,7 +135,7 @@ export function ConversationContextMenu({
     ...(onExport
       ? [
           {
-            label: 'Export',
+            label: t('contextMenu.export'),
             icon: Download,
             onClick: () => {
               onExport(conversation.id);
@@ -144,7 +146,7 @@ export function ConversationContextMenu({
       : []),
     { type: 'separator' },
     {
-      label: 'Delete',
+      label: t('common.delete'),
       icon: Trash2,
       onClick: () => {
         onDelete(conversation.id);
@@ -163,7 +165,7 @@ export function ConversationContextMenu({
         top: position.y,
       }}
       role="menu"
-      aria-label="Conversation actions"
+      aria-label={t('contextMenu.conversationActions')}
     >
       {menuItems.map((item, index) => {
         if (item.type === 'separator') {

--- a/frontend/src/components/sidebar/FilterSortBar.tsx
+++ b/frontend/src/components/sidebar/FilterSortBar.tsx
@@ -8,6 +8,7 @@
  * because conversations store department as a slug, not a UUID.
  */
 
+import { useTranslation } from 'react-i18next';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import type { Department } from '../../types/business';
 import type { Conversation, ConversationSortBy } from '../../types/conversation';
@@ -37,14 +38,17 @@ export function FilterSortBar({
   activeCount = 0,
   archivedCount = 0,
 }: FilterSortBarProps) {
+  const { t } = useTranslation();
   return (
     <div className="sidebar-filter" onClick={(e) => e.stopPropagation()}>
       <Select value={filter} onValueChange={onFilterChange}>
         <SelectTrigger variant="compact" className="filter-select-trigger">
-          <SelectValue placeholder="All Conversations" />
+          <SelectValue placeholder={t('sidebar.allConversations')} />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="all">All Conversations ({activeCount})</SelectItem>
+          <SelectItem value="all">
+            {t('sidebar.allConversationsCount', { count: activeCount })}
+          </SelectItem>
           {departments.map((dept) => {
             // Use slug for grouping key (conversations store department as slug)
             const deptKey = dept.slug || dept.id;
@@ -56,17 +60,23 @@ export function FilterSortBar({
             );
           })}
           {archivedCount > 0 && (
-            <SelectItem value="archived">Archived ({archivedCount})</SelectItem>
+            <SelectItem value="archived">
+              {t('sidebar.archivedCount', { count: archivedCount })}
+            </SelectItem>
           )}
         </SelectContent>
       </Select>
       <Select value={sortBy} onValueChange={onSortByChange}>
-        <SelectTrigger variant="compact" className="sort-select-trigger" title="Sort conversations">
-          <SelectValue placeholder="Latest" />
+        <SelectTrigger
+          variant="compact"
+          className="sort-select-trigger"
+          title={t('sidebar.sortConversations')}
+        >
+          <SelectValue placeholder={t('sidebar.sortLatest')} />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="date">Latest</SelectItem>
-          <SelectItem value="activity">Active</SelectItem>
+          <SelectItem value="date">{t('sidebar.sortLatest')}</SelectItem>
+          <SelectItem value="activity">{t('sidebar.sortActive')}</SelectItem>
         </SelectContent>
       </Select>
     </div>

--- a/frontend/src/components/sidebar/SearchBar.tsx
+++ b/frontend/src/components/sidebar/SearchBar.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useRef, forwardRef, useImperativeHandle } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Spinner } from '../ui/Spinner';
 
 interface SearchBarProps {
@@ -25,6 +26,7 @@ export const SearchBar = forwardRef<SearchBarRef, SearchBarProps>(function Searc
   { searchQuery, onSearchChange, onClear, isSearching, resultCount },
   ref
 ) {
+  const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Expose focus method to parent
@@ -52,8 +54,8 @@ export const SearchBar = forwardRef<SearchBarRef, SearchBarProps>(function Searc
           name="search"
           type="search"
           inputMode="search"
-          placeholder="Search conversations... (⌘K)"
-          aria-label="Search conversations"
+          placeholder={t('sidebar.searchPlaceholder')}
+          aria-label={t('sidebar.searchConversations')}
           aria-describedby={searchQuery ? 'search-results-count' : undefined}
           value={searchQuery}
           onChange={onSearchChange}
@@ -72,7 +74,7 @@ export const SearchBar = forwardRef<SearchBarRef, SearchBarProps>(function Searc
               onClear();
               inputRef.current?.focus();
             }}
-            aria-label="Clear search"
+            aria-label={t('sidebar.clearSearch')}
           >
             ×
           </button>
@@ -85,7 +87,7 @@ export const SearchBar = forwardRef<SearchBarRef, SearchBarProps>(function Searc
           role="status"
           aria-live="polite"
         >
-          {resultCount} result{resultCount !== 1 ? 's' : ''}
+          {t('sidebar.resultsCount', { count: resultCount })}
         </div>
       )}
     </div>

--- a/frontend/src/components/sidebar/SidebarFooter.tsx
+++ b/frontend/src/components/sidebar/SidebarFooter.tsx
@@ -4,6 +4,7 @@
  * Extracted from Sidebar.jsx for better maintainability.
  */
 
+import { useTranslation } from 'react-i18next';
 import { Briefcase } from 'lucide-react';
 import { DEV_MODE } from './hooks';
 
@@ -46,6 +47,7 @@ export function SidebarFooter({
   onCompanyMouseEnter,
   onCompanyMouseLeave,
 }: SidebarFooterProps) {
+  const { t } = useTranslation();
   if (!user) return null;
 
   return (
@@ -57,30 +59,26 @@ export function SidebarFooter({
             className={`mode-toggle-btn ${mockMode ? 'mock' : 'production'} ${isTogglingMock ? 'toggling' : ''}`}
             onClick={onToggleMockMode}
             disabled={isTogglingMock || mockMode === null}
-            title={
-              mockMode
-                ? 'Mock Mode: Using simulated responses (free)'
-                : 'Production Mode: Using real API calls (costs credits)'
-            }
+            title={mockMode ? t('settings.mockModeOn') : t('settings.mockModeOff')}
           >
             <span className="mode-indicator"></span>
             <span className="mode-label">
-              {mockMode === null ? '...' : mockMode ? 'Mock' : 'Prod'}
+              {mockMode === null ? '...' : mockMode ? t('settings.mock') : t('settings.production')}
             </span>
           </button>
           <button
             className={`mode-toggle-btn caching ${cachingMode ? 'enabled' : 'disabled'} ${isTogglingCaching ? 'toggling' : ''}`}
             onClick={onToggleCachingMode}
             disabled={isTogglingCaching || cachingMode === null}
-            title={
-              cachingMode
-                ? 'Caching ON: Reduces costs by caching context (Claude/Gemini)'
-                : 'Caching OFF: Standard API calls'
-            }
+            title={cachingMode ? t('settings.cachingOn') : t('settings.cachingOff')}
           >
             <span className="mode-indicator"></span>
             <span className="mode-label">
-              {cachingMode === null ? '...' : cachingMode ? 'Cache' : 'No Cache'}
+              {cachingMode === null
+                ? '...'
+                : cachingMode
+                  ? t('settings.cache')
+                  : t('settings.noCache')}
             </span>
           </button>
         </div>
@@ -97,16 +95,20 @@ export function SidebarFooter({
           onClick={onOpenMyCompany}
           onMouseEnter={onCompanyMouseEnter}
           onMouseLeave={onCompanyMouseLeave}
-          title="My Company"
+          title={t('sidebar.myCompany')}
         >
           <Briefcase className="h-3.5 w-3.5" />
-          Company
+          {t('mobileNav.company')}
         </button>
-        <button className="settings-btn" onClick={onOpenSettings} title="Settings & Profile">
-          Settings
+        <button
+          className="settings-btn"
+          onClick={onOpenSettings}
+          title={t('sidebar.settingsProfile')}
+        >
+          {t('sidebar.settings')}
         </button>
-        <button className="sign-out-btn" onClick={onSignOut} title="Sign out">
-          Sign Out
+        <button className="sign-out-btn" onClick={onSignOut} title={t('sidebar.signOut')}>
+          {t('auth.signOut')}
         </button>
       </div>
     </div>

--- a/frontend/src/components/stage3/PlaybookDropdown.tsx
+++ b/frontend/src/components/stage3/PlaybookDropdown.tsx
@@ -2,40 +2,32 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Popover from '@radix-ui/react-popover';
 import { BottomSheet } from '../ui/BottomSheet';
-import { BookOpen, ChevronDown, ScrollText, Layers, FileText, LucideIcon } from 'lucide-react';
+import { BookOpen, ChevronDown, ScrollText, Layers, FileText } from 'lucide-react';
 import '../Stage3.css';
 
 type DocType = 'sop' | 'framework' | 'policy' | '';
 type SaveState = 'idle' | 'saving' | 'promoting' | 'saved' | 'promoted' | 'error';
 
-interface DocTypeOption {
-  value: DocType;
-  label: string;
-  icon: LucideIcon;
-  description: string;
-  colorClass: string;
-}
-
-const DOC_TYPE_OPTIONS: DocTypeOption[] = [
+const DOC_TYPE_OPTIONS = [
   {
-    value: 'sop',
-    label: 'SOP',
+    value: 'sop' as DocType,
+    labelKey: 'stages.docTypes.sop' as const,
+    descKey: 'stages.docTypes.sopDesc' as const,
     icon: ScrollText,
-    description: 'Standard Operating Procedure',
     colorClass: 'sop',
   },
   {
-    value: 'framework',
-    label: 'Framework',
+    value: 'framework' as DocType,
+    labelKey: 'stages.docTypes.framework' as const,
+    descKey: 'stages.docTypes.frameworkDesc' as const,
     icon: Layers,
-    description: 'Guidelines and best practices',
     colorClass: 'framework',
   },
   {
-    value: 'policy',
-    label: 'Policy',
+    value: 'policy' as DocType,
+    labelKey: 'stages.docTypes.policy' as const,
+    descKey: 'stages.docTypes.policyDesc' as const,
     icon: FileText,
-    description: 'Rules and requirements',
     colorClass: 'policy',
   },
 ];
@@ -65,6 +57,10 @@ export function PlaybookDropdown({
   const isSaved = saveState === 'saved' || saveState === 'promoted';
   const isDisabled = saveState === 'saving' || saveState === 'promoting';
 
+  // Get translated label and description for selected option
+  const selectedLabel = selectedOption ? t(selectedOption.labelKey) : '';
+  const selectedDesc = selectedOption ? t(selectedOption.descKey) : '';
+
   const handleSelect = (value: DocType) => {
     if (isSaved) return;
     setSelectedDocType(value);
@@ -76,7 +72,7 @@ export function PlaybookDropdown({
       {selectedOption ? (
         <>
           <selectedOption.icon className="h-3.5 w-3.5" />
-          <span>{selectedOption.label}</span>
+          <span>{selectedLabel}</span>
         </>
       ) : (
         <>
@@ -117,8 +113,8 @@ export function PlaybookDropdown({
             >
               <Icon className="h-4 w-4" />
               <div className="toolbar-dropdown-option-text">
-                <span className="toolbar-dropdown-option-name">{option.label}</span>
-                <span className="toolbar-dropdown-option-desc">{option.description}</span>
+                <span className="toolbar-dropdown-option-name">{t(option.labelKey)}</span>
+                <span className="toolbar-dropdown-option-desc">{t(option.descKey)}</span>
               </div>
             </button>
           );
@@ -137,9 +133,9 @@ export function PlaybookDropdown({
           disabled={isDisabled}
           title={
             isSaved && selectedOption
-              ? t('stages.savedAs', { type: selectedOption.label })
+              ? t('stages.savedAs', { type: selectedLabel })
               : selectedOption
-                ? selectedOption.description
+                ? selectedDesc
                 : t('stages.optionallyClassify')
           }
         >
@@ -181,8 +177,8 @@ export function PlaybookDropdown({
                     <Icon className="h-5 w-5" />
                   </div>
                   <div className="toolbar-option-content">
-                    <span className="toolbar-option-name">{option.label}</span>
-                    <span className="toolbar-option-desc">{option.description}</span>
+                    <span className="toolbar-option-name">{t(option.labelKey)}</span>
+                    <span className="toolbar-option-desc">{t(option.descKey)}</span>
                   </div>
                 </button>
               );
@@ -207,9 +203,9 @@ export function PlaybookDropdown({
           disabled={isDisabled}
           title={
             isSaved && selectedOption
-              ? t('stages.savedAs', { type: selectedOption.label })
+              ? t('stages.savedAs', { type: selectedLabel })
               : selectedOption
-                ? selectedOption.description
+                ? selectedDesc
                 : t('stages.optionallyClassify')
           }
         >

--- a/frontend/src/components/ui/CommandPalette.tsx
+++ b/frontend/src/components/ui/CommandPalette.tsx
@@ -13,6 +13,7 @@
  */
 
 import { useEffect, useMemo, useSyncExternalStore } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Command } from 'cmdk';
 import { createPortal } from 'react-dom';
 import type { Conversation } from '../../types/conversation';
@@ -353,6 +354,7 @@ export function CommandPalette({
   theme,
   onThemeChange,
 }: CommandPaletteProps) {
+  const { t } = useTranslation();
   const mounted = useIsMounted();
 
   // Build actions list
@@ -362,8 +364,8 @@ export function CommandPalette({
     // === NAVIGATION ===
     list.push({
       id: 'nav-settings',
-      label: 'Open Settings',
-      description: 'Profile, billing, team, API keys',
+      label: t('commandPalette.actions.openSettings'),
+      description: t('commandPalette.actions.openSettingsDesc'),
       icon: <Icons.Settings />,
       category: 'navigation',
       keywords: ['preferences', 'account', 'profile'],
@@ -376,8 +378,8 @@ export function CommandPalette({
 
     list.push({
       id: 'nav-mycompany',
-      label: 'Open My Company',
-      description: 'Departments, roles, playbooks, decisions',
+      label: t('commandPalette.actions.openMyCompany'),
+      description: t('commandPalette.actions.openMyCompanyDesc'),
       icon: <Icons.Building />,
       category: 'navigation',
       keywords: ['company', 'organization', 'business', 'knowledge'],
@@ -389,8 +391,8 @@ export function CommandPalette({
 
     list.push({
       id: 'nav-leaderboard',
-      label: 'Open Leaderboard',
-      description: 'Model performance rankings',
+      label: t('commandPalette.actions.openLeaderboard'),
+      description: t('commandPalette.actions.openLeaderboardDesc'),
       icon: <Icons.Trophy />,
       category: 'navigation',
       keywords: ['rankings', 'models', 'performance', 'stats'],
@@ -402,8 +404,8 @@ export function CommandPalette({
 
     list.push({
       id: 'nav-llmhub',
-      label: 'Open LLM Hub',
-      description: 'Configure AI models and presets',
+      label: t('commandPalette.actions.openLLMHub'),
+      description: t('commandPalette.actions.openLLMHubDesc'),
       icon: <Icons.Brain />,
       category: 'navigation',
       keywords: ['ai', 'models', 'config', 'gpt', 'claude', 'gemini'],
@@ -416,8 +418,8 @@ export function CommandPalette({
     // === CREATE ===
     list.push({
       id: 'create-conversation',
-      label: 'New Council Session',
-      description: 'Start a new AI council deliberation',
+      label: t('commandPalette.actions.newSession'),
+      description: t('commandPalette.actions.newSessionDesc'),
       icon: <Icons.Plus />,
       category: 'create',
       keywords: ['new', 'chat', 'conversation', 'ask', 'question'],
@@ -436,7 +438,7 @@ export function CommandPalette({
     recentConversations.forEach((conv) => {
       list.push({
         id: `conv-${conv.id}`,
-        label: conv.title || 'Untitled Conversation',
+        label: conv.title || t('commandPalette.actions.untitledConversation'),
         description: conv.created_at ? new Date(conv.created_at).toLocaleDateString() : undefined,
         icon: <Icons.MessageSquare />,
         category: 'conversations',
@@ -452,8 +454,8 @@ export function CommandPalette({
     projects.slice(0, 5).forEach((project) => {
       list.push({
         id: `project-${project.id}`,
-        label: `Switch to: ${project.name}`,
-        description: project.description || 'Project',
+        label: t('commandPalette.actions.switchToProject', { name: project.name }),
+        description: project.description || t('projects.title'),
         icon: <Icons.Folder />,
         category: 'projects',
         keywords: ['project', 'initiative', 'switch'],
@@ -467,8 +469,8 @@ export function CommandPalette({
     if (selectedProject) {
       list.push({
         id: 'project-clear',
-        label: 'Clear Project Selection',
-        description: 'Remove project context from conversations',
+        label: t('commandPalette.actions.clearProject'),
+        description: t('commandPalette.actions.clearProjectDesc'),
         icon: <Icons.Folder />,
         category: 'projects',
         keywords: ['clear', 'remove', 'project'],
@@ -482,7 +484,7 @@ export function CommandPalette({
     // === THEME ===
     list.push({
       id: 'theme-light',
-      label: 'Switch to Light Mode',
+      label: t('commandPalette.actions.lightMode'),
       icon: <Icons.Sun />,
       category: 'theme',
       keywords: ['theme', 'light', 'bright', 'day'],
@@ -494,7 +496,7 @@ export function CommandPalette({
 
     list.push({
       id: 'theme-dark',
-      label: 'Switch to Dark Mode',
+      label: t('commandPalette.actions.darkMode'),
       icon: <Icons.Moon />,
       category: 'theme',
       keywords: ['theme', 'dark', 'night'],
@@ -506,8 +508,8 @@ export function CommandPalette({
 
     list.push({
       id: 'theme-system',
-      label: 'Use System Theme',
-      description: 'Match your OS preference',
+      label: t('commandPalette.actions.systemTheme'),
+      description: t('commandPalette.actions.systemThemeDesc'),
       icon: theme === 'dark' ? <Icons.Moon /> : <Icons.Sun />,
       category: 'theme',
       keywords: ['theme', 'system', 'auto', 'os'],
@@ -519,6 +521,7 @@ export function CommandPalette({
 
     return list;
   }, [
+    t,
     onOpenSettings,
     onOpenMyCompany,
     onOpenLeaderboard,
@@ -556,12 +559,12 @@ export function CommandPalette({
   }, [actions]);
 
   const categoryLabels: Record<ActionCategory, string> = {
-    navigation: 'Navigation',
-    create: 'Create',
-    conversations: 'Recent Conversations',
-    projects: 'Projects',
-    settings: 'Settings',
-    theme: 'Theme',
+    navigation: t('commandPalette.navigation'),
+    create: t('commandPalette.create'),
+    conversations: t('commandPalette.recentConversations'),
+    projects: t('projects.title'),
+    settings: t('settings.title'),
+    theme: t('commandPalette.theme'),
   };
 
   // Handle keyboard shortcut
@@ -592,14 +595,14 @@ export function CommandPalette({
             <Icons.Search />
             <Command.Input
               className="command-palette-input"
-              placeholder="Type a command or search..."
+              placeholder={t('commandPalette.placeholder')}
               autoFocus
             />
             <kbd className="command-palette-kbd">ESC</kbd>
           </div>
 
           <Command.List className="command-palette-list">
-            <Command.Empty className="command-palette-empty">No results found.</Command.Empty>
+            <Command.Empty className="command-palette-empty">{t('common.noResults')}</Command.Empty>
 
             {/* Render groups that have items */}
             {(Object.keys(groupedActions) as ActionCategory[]).map((category) => {

--- a/frontend/src/components/ui/SortSelect.tsx
+++ b/frontend/src/components/ui/SortSelect.tsx
@@ -6,6 +6,7 @@
  */
 
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { Check, ChevronDown, ArrowUpDown } from 'lucide-react';
 import { cn } from '../../lib/utils';
@@ -15,18 +16,15 @@ import './SortSelect.css';
 // Check if we're on mobile/tablet for bottom sheet vs dropdown
 const isMobileDevice = () => typeof window !== 'undefined' && window.innerWidth <= 768;
 
-interface SortOption {
-  value: string;
-  label: string;
-}
-
-// Sort option definitions - compact labels for filters
-const defaultSortOptions: SortOption[] = [
-  { value: 'updated', label: 'Latest' },
-  { value: 'created', label: 'Newest' },
-  { value: 'name', label: 'A-Z' },
-  { value: 'decisions', label: 'Decisions' },
+// Sort option definitions with translation keys
+const defaultSortOptionKeys = [
+  { value: 'updated', labelKey: 'common.sortOptions.latest' as const },
+  { value: 'created', labelKey: 'common.sortOptions.newest' as const },
+  { value: 'name', labelKey: 'common.sortOptions.alphabetical' as const },
+  { value: 'decisions', labelKey: 'common.sortOptions.decisions' as const },
 ];
+
+type SortOption = (typeof defaultSortOptionKeys)[number];
 
 // Custom SelectItem
 const SortSelectItem = React.forwardRef<
@@ -57,11 +55,12 @@ export function SortSelect({
   onValueChange,
   disabled = false,
   className,
-  options = defaultSortOptions,
+  options = defaultSortOptionKeys,
 }: SortSelectProps) {
+  const { t } = useTranslation();
   const [open, setOpen] = React.useState(false);
   const selectedOption = options.find((o) => o.value === value) ??
-    options[0] ?? { value: '', label: '' };
+    options[0] ?? { value: '', labelKey: 'common.sortOptions.latest' };
 
   const handleSelect = (optionValue: string) => {
     onValueChange(optionValue);
@@ -79,11 +78,11 @@ export function SortSelect({
           type="button"
         >
           <ArrowUpDown className="h-3.5 w-3.5" />
-          <span>{selectedOption.label}</span>
+          <span>{t(selectedOption.labelKey)}</span>
           <ChevronDown className="h-4 w-4 opacity-50 shrink-0" />
         </button>
 
-        <BottomSheet isOpen={open} onClose={() => setOpen(false)} title="Sort By">
+        <BottomSheet isOpen={open} onClose={() => setOpen(false)} title={t('common.sortBy')}>
           <div className="sort-select-list-mobile">
             {options.map((option) => {
               const isSelected = option.value === value;
@@ -97,7 +96,7 @@ export function SortSelect({
                   <div className={cn('sort-select-radio', isSelected && 'checked')}>
                     {isSelected && <Check className="h-3 w-3" />}
                   </div>
-                  <span className="sort-select-item-label">{option.label}</span>
+                  <span className="sort-select-item-label">{t(option.labelKey)}</span>
                 </button>
               );
             })}
@@ -112,7 +111,7 @@ export function SortSelect({
     <SelectPrimitive.Root value={value} onValueChange={onValueChange} disabled={disabled}>
       <SelectPrimitive.Trigger className={cn('sort-select-trigger', className)}>
         <ArrowUpDown className="h-3.5 w-3.5" />
-        <SelectPrimitive.Value>{selectedOption.label}</SelectPrimitive.Value>
+        <SelectPrimitive.Value>{t(selectedOption.labelKey)}</SelectPrimitive.Value>
         <SelectPrimitive.Icon asChild>
           <ChevronDown className="h-4 w-4 opacity-50 shrink-0" />
         </SelectPrimitive.Icon>
@@ -128,7 +127,7 @@ export function SortSelect({
           <SelectPrimitive.Viewport className="sort-select-viewport">
             {options.map((option) => (
               <SortSelectItem key={option.value} value={option.value}>
-                {option.label}
+                {t(option.labelKey)}
               </SortSelectItem>
             ))}
           </SelectPrimitive.Viewport>

--- a/frontend/src/components/ui/ThemeToggle.tsx
+++ b/frontend/src/components/ui/ThemeToggle.tsx
@@ -9,7 +9,8 @@
  */
 
 import { useTheme } from 'next-themes';
-import { useSyncExternalStore, useCallback } from 'react';
+import { useSyncExternalStore, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Sun, Moon, Monitor } from 'lucide-react';
 import './ThemeToggle.css';
 
@@ -26,16 +27,21 @@ function useIsMounted() {
 const themeCycle = ['light', 'dark', 'system'] as const;
 type ThemeValue = (typeof themeCycle)[number];
 
-// Theme info for tooltips
-const themeInfo: Record<ThemeValue, { label: string; description: string }> = {
-  light: { label: 'Light', description: 'Bright background with dark text' },
-  dark: { label: 'Dark', description: 'Dark background with light text' },
-  system: { label: 'System', description: 'Matches your device settings' },
-};
-
 export function ThemeToggle() {
+  const { t } = useTranslation();
   const { theme, resolvedTheme, setTheme } = useTheme();
   const mounted = useIsMounted();
+
+  // Build translated theme info
+  const themeInfo = useMemo(
+    () =>
+      ({
+        light: { label: t('theme.light'), description: t('theme.lightDesc') },
+        dark: { label: t('theme.dark'), description: t('theme.darkDesc') },
+        system: { label: t('theme.system'), description: t('theme.systemDesc') },
+      }) as Record<ThemeValue, { label: string; description: string }>,
+    [t]
+  );
 
   // Cycle to next theme on click
   // Set timestamp FIRST so onClose handlers can detect and skip closing
@@ -78,7 +84,7 @@ export function ThemeToggle() {
   if (!mounted) {
     return (
       <div className="theme-toggle-container">
-        <button className="theme-toggle-btn" disabled aria-label="Loading theme">
+        <button className="theme-toggle-btn" disabled aria-label={t('common.loading')}>
           <Monitor size={16} />
         </button>
       </div>
@@ -100,7 +106,9 @@ export function ThemeToggle() {
   // For system theme, show what it resolved to
   const currentLabel =
     currentTheme === 'system'
-      ? `System (${resolvedTheme === 'dark' ? 'Dark' : 'Light'})`
+      ? t('theme.systemResolved', {
+          resolved: resolvedTheme === 'dark' ? t('theme.dark') : t('theme.light'),
+        })
       : currentInfo.label;
 
   // Render directly - no portal. CSS handles fixed positioning.
@@ -111,8 +119,8 @@ export function ThemeToggle() {
         onClick={handleClick}
         onPointerDown={handlePointerDown}
         onMouseDown={handleMouseDown}
-        aria-label={`Current: ${currentLabel}. Click to switch to ${nextInfo.label}.`}
-        title={`${currentLabel} — Click for ${nextInfo.label}`}
+        aria-label={t('theme.currentLabel', { current: currentLabel, next: nextInfo.label })}
+        title={t('theme.switchTo', { current: currentLabel, next: nextInfo.label })}
       >
         <Icon size={16} />
       </button>

--- a/frontend/src/contexts/ConversationContext.tsx
+++ b/frontend/src/contexts/ConversationContext.tsx
@@ -24,6 +24,7 @@ import {
   type ReactNode,
   type MutableRefObject,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../api';
 import { useAuth } from '../AuthContext';
@@ -111,6 +112,7 @@ interface ConversationProviderProps {
 }
 
 export function ConversationProvider({ children }: ConversationProviderProps) {
+  const { t } = useTranslation();
   const { isAuthenticated } = useAuth();
   const queryClient = useQueryClient();
 
@@ -539,10 +541,10 @@ export function ConversationProvider({ children }: ConversationProviderProps) {
         }
       };
 
-      toast('Conversation deleted', {
-        description: conversationToDelete.title || 'New Conversation',
+      toast(t('toasts.conversationDeleted'), {
+        description: conversationToDelete.title || t('common.newConversation'),
         action: {
-          label: 'Undo',
+          label: t('common.undo'),
           onClick: () => {
             undoClicked = true;
             setConversations((prev) => {
@@ -553,7 +555,7 @@ export function ConversationProvider({ children }: ConversationProviderProps) {
             if (wasCurrentConversation) {
               setCurrentConversationId(id);
             }
-            toast.success('Conversation restored');
+            toast.success(t('toasts.conversationRestored'));
           },
         },
         duration: 5000,
@@ -561,7 +563,7 @@ export function ConversationProvider({ children }: ConversationProviderProps) {
         onAutoClose: executeDelete,
       });
     },
-    [conversations, currentConversationId, deleteMutation, setCurrentConversationId]
+    [conversations, currentConversationId, deleteMutation, setCurrentConversationId, t]
   );
 
   // Rename a conversation

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,4 +1,11 @@
 {
+  "toasts": {
+    "conversationDeleted": "Conversation deleted",
+    "conversationRestored": "Conversation restored",
+    "conversationsDeleted": "{{count}} conversations deleted",
+    "conversationsRestored": "{{count}} conversations restored",
+    "deleteConversationsFailed": "Failed to delete conversations"
+  },
   "landing": {
     "headline": "The only AI worth",
     "headlineEmphasis": "trusting.",
@@ -6,7 +13,21 @@
     "statsAIs": "AIs",
     "statsRound": "round",
     "statsRounds": "rounds",
-    "statsAnswer": "answer"
+    "statsAnswer": "answer",
+    "quickActions": {
+      "writePitch": "Write a pitch",
+      "writePitchPrompt": "Help me write a compelling pitch for ",
+      "reviewDocument": "Review a document",
+      "reviewDocumentPrompt": "Please review this document and identify any issues: ",
+      "planLaunch": "Plan a launch",
+      "planLaunchPrompt": "Help me plan the launch strategy for ",
+      "analyzeDecision": "Analyze a decision",
+      "analyzeDecisionPrompt": "I need to make a decision about ",
+      "handleSituation": "Handle a situation",
+      "handleSituationPrompt": "Help me handle this situation: ",
+      "improveMetrics": "Improve metrics",
+      "improveMetricsPrompt": "How can I improve "
+    }
   },
   "errorBoundary": {
     "title": "Oops, something broke",
@@ -89,7 +110,105 @@
     "select": "Select",
     "tryAgain": "Try Again",
     "failedToSave": "Failed to save",
-    "unknownError": "An unknown error occurred"
+    "unknownError": "An unknown error occurred",
+    "undo": "Undo",
+    "newConversation": "New Conversation",
+    "keepOriginal": "Keep Original",
+    "useSuggestion": "Use Suggestion",
+    "suggestedTitle": "Suggested title",
+    "sortBy": "Sort By",
+    "sortOptions": {
+      "latest": "Latest",
+      "newest": "Newest",
+      "alphabetical": "A-Z",
+      "decisions": "Decisions"
+    }
+  },
+  "theme": {
+    "light": "Light",
+    "lightDesc": "Bright background with dark text",
+    "dark": "Dark",
+    "darkDesc": "Dark background with light text",
+    "system": "System",
+    "systemDesc": "Matches your device settings",
+    "systemResolved": "System ({{resolved}})",
+    "currentLabel": "Current: {{current}}. Click to switch to {{next}}.",
+    "switchTo": "{{current}} — Click for {{next}}"
+  },
+  "aiAssist": {
+    "suggestion": "AI Suggestion",
+    "noSuggestion": "No suggestion returned",
+    "failedToGet": "Failed to get suggestion",
+    "contexts": {
+      "projectTitle": {
+        "placeholder": "Describe your project briefly...",
+        "button": "Write title for me",
+        "hint": "Type a few words about your project"
+      },
+      "projectDescription": {
+        "placeholder": "What is this project about?",
+        "button": "AI, rewrite this better",
+        "hint": "Describe what you're building"
+      },
+      "projectContext": {
+        "placeholder": "Tell us about your project...",
+        "button": "AI, rewrite this better",
+        "hint": "Just type what you know about the project"
+      },
+      "companyContext": {
+        "placeholder": "Tell us about your company...",
+        "button": "Write it nicely for me",
+        "hint": "Just type what you know"
+      },
+      "departmentDescription": {
+        "placeholder": "What does this department handle?",
+        "button": "Help me write this",
+        "hint": "Describe what this team does"
+      },
+      "roleDescription": {
+        "placeholder": "What does this role do?",
+        "button": "Help me write this",
+        "hint": "Describe what this person does"
+      },
+      "rolePrompt": {
+        "placeholder": "Describe the role...",
+        "button": "Write instructions",
+        "hint": "Describe what kind of advisor this should be"
+      },
+      "playbookContent": {
+        "placeholder": "Describe what you need (e.g., 'how we onboard new customers')...",
+        "button": "Let our expert write this",
+        "buttonSop": "Let our SOP expert write this",
+        "buttonFramework": "Let our framework expert write this",
+        "buttonPolicy": "Let our policy expert write this",
+        "hint": "Type a brief description - AI will write the full document"
+      },
+      "decisionTitle": {
+        "placeholder": "What was decided?",
+        "button": "Write title for me",
+        "hint": "Summarize the decision briefly"
+      },
+      "decisionStatement": {
+        "placeholder": "What was decided?",
+        "button": "Make it clearer",
+        "hint": "State what was decided"
+      },
+      "knowledgeReasoning": {
+        "placeholder": "Why was this decided?",
+        "button": "Help me explain",
+        "hint": "Add any reasoning you remember"
+      },
+      "questionRefine": {
+        "placeholder": "What do you want to ask?",
+        "button": "Help me ask better",
+        "hint": "Type your question"
+      },
+      "generic": {
+        "placeholder": "Enter your text...",
+        "button": "Help me write this",
+        "hint": "Type something"
+      }
+    }
   },
   "help": {
     "title": "Help & Support",
@@ -218,7 +337,25 @@
     "startNewConversation": "Start a new conversation to ask your council",
     "nothingArchived": "Nothing archived yet",
     "noActiveConversations": "No active conversations",
-    "scrollForMore": "Scroll for more conversations"
+    "scrollForMore": "Scroll for more conversations",
+    "searchPlaceholder": "Search conversations... (⌘K)",
+    "resultsCount": "{{count}} result",
+    "resultsCount_other": "{{count}} results",
+    "allConversations": "All Conversations",
+    "allConversationsCount": "All Conversations ({{count}})",
+    "archivedCount": "Archived ({{count}})",
+    "sortConversations": "Sort conversations",
+    "sortLatest": "Latest",
+    "sortActive": "Active",
+    "settingsProfile": "Settings & Profile",
+    "signOut": "Sign out",
+    "deleting": "Deleting...",
+    "bulkActions": "Bulk actions",
+    "selectedCount": "{{count}} selected",
+    "cancelSelection": "Cancel selection",
+    "deletingConversations": "Deleting conversations",
+    "deleteConversations": "Delete {{count}} conversation",
+    "deleteConversations_other": "Delete {{count}} conversations"
   },
   "settings": {
     "title": "Settings",
@@ -339,7 +476,30 @@
     "tokenUsageOff": "Token usage hidden from UI",
     "visible": "Visible",
     "hidden": "Hidden",
-    "tokenUsageInfo": "Token usage will be displayed below each council stage."
+    "tokenUsageInfo": "Token usage will be displayed below each council stage.",
+    "mockLengthOverride": "Response Length Override",
+    "mockLengthOverrideDesc": "Test different lengths without changing LLM Hub",
+    "mockLengthOverrideActive": "Override active: Mock will use {{tokens}} tokens regardless of LLM Hub settings",
+    "mockLength": {
+      "useDefault": "Use LLM Hub Settings",
+      "useDefaultDesc": "Respects your production config",
+      "short": "Short (~1 paragraph)",
+      "shortDesc": "512 tokens",
+      "medium": "Medium (~1 page)",
+      "mediumDesc": "1536 tokens",
+      "long": "Long (~2-3 pages)",
+      "longDesc": "4096 tokens",
+      "veryLong": "Very Long (~4+ pages)",
+      "veryLongDesc": "8192 tokens"
+    },
+    "roleLabels": {
+      "owner": "Owner",
+      "ownerDesc": "Full control",
+      "admin": "Admin",
+      "adminDesc": "Manage members",
+      "member": "Member",
+      "memberDesc": "View & contribute"
+    }
   },
   "company": {
     "overview": "Overview",
@@ -462,6 +622,14 @@
     "savedAs": "Saved as {{type}}",
     "optionallyClassify": "Optionally classify as a playbook type",
     "selectPlaybookType": "Select Playbook Type",
+    "docTypes": {
+      "sop": "SOP",
+      "sopDesc": "Standard Operating Procedure",
+      "framework": "Framework",
+      "frameworkDesc": "Guidelines and best practices",
+      "policy": "Policy",
+      "policyDesc": "Rules and requirements"
+    },
     "selectProject": "Select Project",
     "noProject": "No Project",
     "saveWithoutProject": "Save without linking to a project",
@@ -1106,7 +1274,19 @@
     "queriesRemaining": "{{count}} queries remaining",
     "queriesUnlimited": "Unlimited queries",
     "nextBillingDate": "Next billing date",
-    "cancelSubscription": "Cancel Subscription"
+    "cancelSubscription": "Cancel Subscription",
+    "loadingBilling": "Loading billing information...",
+    "loadError": "Couldn't load your billing info. Please try again.",
+    "portalError": "Couldn't open billing portal. Please try again.",
+    "subscriptionPlans": "Subscription Plans",
+    "currentUsage": "Current Usage",
+    "queriesUsedUnlimited": "{{count}} queries used (Unlimited)",
+    "queriesUsedMonthly": "{{used}} / {{limit}} queries this month",
+    "mostPopular": "Most Popular",
+    "cancelToDowngrade": "Cancel subscription to downgrade to Free",
+    "subscribe": "Subscribe",
+    "manageSubscriptionBilling": "Manage Subscription & Billing",
+    "stripePowered": "Secure payments powered by Stripe"
   },
   "leaderboard": {
     "title": "Model Leaderboard",
@@ -1155,6 +1335,42 @@
   "modeToggle": {
     "quick": "Quick",
     "fullCouncil": "Full Council"
+  },
+  "commandPalette": {
+    "placeholder": "Type a command or search...",
+    "navigation": "Navigation",
+    "create": "Create",
+    "recentConversations": "Recent Conversations",
+    "theme": "Theme",
+    "actions": {
+      "openSettings": "Open Settings",
+      "openSettingsDesc": "Profile, billing, team, API keys",
+      "openMyCompany": "Open My Company",
+      "openMyCompanyDesc": "Departments, roles, playbooks, decisions",
+      "openLeaderboard": "Open Leaderboard",
+      "openLeaderboardDesc": "Model performance rankings",
+      "openLLMHub": "Open LLM Hub",
+      "openLLMHubDesc": "Configure AI models and presets",
+      "newSession": "New Council Session",
+      "newSessionDesc": "Start a new AI council deliberation",
+      "untitledConversation": "Untitled Conversation",
+      "switchToProject": "Switch to: {{name}}",
+      "clearProject": "Clear Project Selection",
+      "clearProjectDesc": "Remove project context from conversations",
+      "lightMode": "Switch to Light Mode",
+      "darkMode": "Switch to Dark Mode",
+      "systemTheme": "Use System Theme",
+      "systemThemeDesc": "Match your OS preference"
+    }
+  },
+  "contextMenu": {
+    "conversationActions": "Conversation actions",
+    "rename": "Rename",
+    "addStar": "Add star",
+    "removeStar": "Remove star",
+    "archive": "Archive",
+    "unarchive": "Unarchive",
+    "export": "Export"
   },
   "validation": {
     "required": "This field is required",
@@ -1314,6 +1530,8 @@
     "avgTokensPerSession": "Avg tokens/session",
     "rankingParseRate": "Ranking parse rate",
     "inputTokens": "Input tokens",
-    "outputTokens": "Output tokens"
+    "outputTokens": "Output tokens",
+    "loadingTeam": "Loading team...",
+    "joined": "Joined"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1,4 +1,11 @@
 {
+  "toasts": {
+    "conversationDeleted": "Conversación eliminada",
+    "conversationRestored": "Conversación restaurada",
+    "conversationsDeleted": "{{count}} conversaciones eliminadas",
+    "conversationsRestored": "{{count}} conversaciones restauradas",
+    "deleteConversationsFailed": "Error al eliminar conversaciones"
+  },
   "landing": {
     "headline": "La única IA en la que",
     "headlineEmphasis": "confiar.",
@@ -6,7 +13,21 @@
     "statsAIs": "IAs",
     "statsRound": "ronda",
     "statsRounds": "rondas",
-    "statsAnswer": "respuesta"
+    "statsAnswer": "respuesta",
+    "quickActions": {
+      "writePitch": "Escribir un pitch",
+      "writePitchPrompt": "Ayúdame a escribir un pitch convincente para ",
+      "reviewDocument": "Revisar un documento",
+      "reviewDocumentPrompt": "Por favor revisa este documento e identifica problemas: ",
+      "planLaunch": "Planificar un lanzamiento",
+      "planLaunchPrompt": "Ayúdame a planificar la estrategia de lanzamiento para ",
+      "analyzeDecision": "Analizar una decisión",
+      "analyzeDecisionPrompt": "Necesito tomar una decisión sobre ",
+      "handleSituation": "Manejar una situación",
+      "handleSituationPrompt": "Ayúdame a manejar esta situación: ",
+      "improveMetrics": "Mejorar métricas",
+      "improveMetricsPrompt": "¿Cómo puedo mejorar "
+    }
   },
   "errorBoundary": {
     "title": "Vaya, algo salió mal",
@@ -89,7 +110,105 @@
     "select": "Seleccionar",
     "tryAgain": "Intentar de Nuevo",
     "failedToSave": "Error al guardar",
-    "unknownError": "Ocurrió un error desconocido"
+    "unknownError": "Ocurrió un error desconocido",
+    "undo": "Deshacer",
+    "newConversation": "Nueva Conversación",
+    "keepOriginal": "Mantener Original",
+    "useSuggestion": "Usar Sugerencia",
+    "suggestedTitle": "Título sugerido",
+    "sortBy": "Ordenar Por",
+    "sortOptions": {
+      "latest": "Más Reciente",
+      "newest": "Más Nuevo",
+      "alphabetical": "A-Z",
+      "decisions": "Decisiones"
+    }
+  },
+  "theme": {
+    "light": "Claro",
+    "lightDesc": "Fondo claro con texto oscuro",
+    "dark": "Oscuro",
+    "darkDesc": "Fondo oscuro con texto claro",
+    "system": "Sistema",
+    "systemDesc": "Coincide con la configuración de tu dispositivo",
+    "systemResolved": "Sistema ({{resolved}})",
+    "currentLabel": "Actual: {{current}}. Clic para cambiar a {{next}}.",
+    "switchTo": "{{current}} — Clic para {{next}}"
+  },
+  "aiAssist": {
+    "suggestion": "Sugerencia de IA",
+    "noSuggestion": "No se obtuvo sugerencia",
+    "failedToGet": "Error al obtener sugerencia",
+    "contexts": {
+      "projectTitle": {
+        "placeholder": "Describe tu proyecto brevemente...",
+        "button": "Escribe el título por mí",
+        "hint": "Escribe algunas palabras sobre tu proyecto"
+      },
+      "projectDescription": {
+        "placeholder": "¿De qué se trata este proyecto?",
+        "button": "IA, reescríbelo mejor",
+        "hint": "Describe lo que estás construyendo"
+      },
+      "projectContext": {
+        "placeholder": "Cuéntanos sobre tu proyecto...",
+        "button": "IA, reescríbelo mejor",
+        "hint": "Solo escribe lo que sepas del proyecto"
+      },
+      "companyContext": {
+        "placeholder": "Cuéntanos sobre tu empresa...",
+        "button": "Escríbelo bien por mí",
+        "hint": "Solo escribe lo que sepas"
+      },
+      "departmentDescription": {
+        "placeholder": "¿Qué maneja este departamento?",
+        "button": "Ayúdame a escribir esto",
+        "hint": "Describe qué hace este equipo"
+      },
+      "roleDescription": {
+        "placeholder": "¿Qué hace este rol?",
+        "button": "Ayúdame a escribir esto",
+        "hint": "Describe qué hace esta persona"
+      },
+      "rolePrompt": {
+        "placeholder": "Describe el rol...",
+        "button": "Escribir instrucciones",
+        "hint": "Describe qué tipo de asesor debería ser"
+      },
+      "playbookContent": {
+        "placeholder": "Describe lo que necesitas (ej. 'cómo incorporamos nuevos clientes')...",
+        "button": "Deja que nuestro experto lo escriba",
+        "buttonSop": "Deja que nuestro experto en SOP lo escriba",
+        "buttonFramework": "Deja que nuestro experto en frameworks lo escriba",
+        "buttonPolicy": "Deja que nuestro experto en políticas lo escriba",
+        "hint": "Escribe una breve descripción - la IA escribirá el documento completo"
+      },
+      "decisionTitle": {
+        "placeholder": "¿Qué se decidió?",
+        "button": "Escribe el título por mí",
+        "hint": "Resume la decisión brevemente"
+      },
+      "decisionStatement": {
+        "placeholder": "¿Qué se decidió?",
+        "button": "Hazlo más claro",
+        "hint": "Indica qué se decidió"
+      },
+      "knowledgeReasoning": {
+        "placeholder": "¿Por qué se decidió esto?",
+        "button": "Ayúdame a explicar",
+        "hint": "Agrega el razonamiento que recuerdes"
+      },
+      "questionRefine": {
+        "placeholder": "¿Qué quieres preguntar?",
+        "button": "Ayúdame a preguntar mejor",
+        "hint": "Escribe tu pregunta"
+      },
+      "generic": {
+        "placeholder": "Ingresa tu texto...",
+        "button": "Ayúdame a escribir esto",
+        "hint": "Escribe algo"
+      }
+    }
   },
   "help": {
     "title": "Ayuda y Soporte",
@@ -218,7 +337,25 @@
     "startNewConversation": "Inicia una nueva conversación para preguntar a tu consejo",
     "nothingArchived": "Nada archivado aún",
     "noActiveConversations": "Sin conversaciones activas",
-    "scrollForMore": "Desplaza para más conversaciones"
+    "scrollForMore": "Desplaza para más conversaciones",
+    "searchPlaceholder": "Buscar conversaciones... (⌘K)",
+    "resultsCount": "{{count}} resultado",
+    "resultsCount_other": "{{count}} resultados",
+    "allConversations": "Todas las conversaciones",
+    "allConversationsCount": "Todas las conversaciones ({{count}})",
+    "archivedCount": "Archivadas ({{count}})",
+    "sortConversations": "Ordenar conversaciones",
+    "sortLatest": "Más recientes",
+    "sortActive": "Activas",
+    "settingsProfile": "Configuración y Perfil",
+    "signOut": "Cerrar sesión",
+    "deleting": "Eliminando...",
+    "bulkActions": "Acciones masivas",
+    "selectedCount": "{{count}} seleccionados",
+    "cancelSelection": "Cancelar selección",
+    "deletingConversations": "Eliminando conversaciones",
+    "deleteConversations": "Eliminar {{count}} conversación",
+    "deleteConversations_other": "Eliminar {{count}} conversaciones"
   },
   "settings": {
     "title": "Configuración",
@@ -339,7 +476,30 @@
     "tokenUsageOff": "Uso de tokens oculto de la UI",
     "visible": "Visible",
     "hidden": "Oculto",
-    "tokenUsageInfo": "El uso de tokens se mostrará debajo de cada etapa del consejo."
+    "tokenUsageInfo": "El uso de tokens se mostrará debajo de cada etapa del consejo.",
+    "mockLengthOverride": "Anular longitud de respuesta",
+    "mockLengthOverrideDesc": "Prueba diferentes longitudes sin cambiar el Hub de LLM",
+    "mockLengthOverrideActive": "Anulación activa: El modo simulado usará {{tokens}} tokens sin importar la configuración del Hub de LLM",
+    "mockLength": {
+      "useDefault": "Usar configuración del Hub de LLM",
+      "useDefaultDesc": "Respeta tu configuración de producción",
+      "short": "Corto (~1 párrafo)",
+      "shortDesc": "512 tokens",
+      "medium": "Medio (~1 página)",
+      "mediumDesc": "1536 tokens",
+      "long": "Largo (~2-3 páginas)",
+      "longDesc": "4096 tokens",
+      "veryLong": "Muy largo (~4+ páginas)",
+      "veryLongDesc": "8192 tokens"
+    },
+    "roleLabels": {
+      "owner": "Propietario",
+      "ownerDesc": "Control total",
+      "admin": "Administrador",
+      "adminDesc": "Gestionar miembros",
+      "member": "Miembro",
+      "memberDesc": "Ver y contribuir"
+    }
   },
   "company": {
     "overview": "Resumen",
@@ -462,6 +622,14 @@
     "savedAs": "Guardado como {{type}}",
     "optionallyClassify": "Opcionalmente clasificar como tipo de playbook",
     "selectPlaybookType": "Seleccionar tipo de Playbook",
+    "docTypes": {
+      "sop": "SOP",
+      "sopDesc": "Procedimiento Operativo Estándar",
+      "framework": "Marco",
+      "frameworkDesc": "Directrices y mejores prácticas",
+      "policy": "Política",
+      "policyDesc": "Reglas y requisitos"
+    },
     "selectProject": "Seleccionar proyecto",
     "noProject": "Sin proyecto",
     "saveWithoutProject": "Guardar sin vincular a un proyecto",
@@ -1106,7 +1274,19 @@
     "queriesRemaining": "{{count}} consultas restantes",
     "queriesUnlimited": "Consultas ilimitadas",
     "nextBillingDate": "Próxima fecha de facturación",
-    "cancelSubscription": "Cancelar suscripción"
+    "cancelSubscription": "Cancelar suscripción",
+    "loadingBilling": "Cargando información de facturación...",
+    "loadError": "No se pudo cargar tu información de facturación. Por favor, inténtalo de nuevo.",
+    "portalError": "No se pudo abrir el portal de facturación. Por favor, inténtalo de nuevo.",
+    "subscriptionPlans": "Planes de Suscripción",
+    "currentUsage": "Uso Actual",
+    "queriesUsedUnlimited": "{{count}} consultas usadas (Ilimitado)",
+    "queriesUsedMonthly": "{{used}} / {{limit}} consultas este mes",
+    "mostPopular": "Más Popular",
+    "cancelToDowngrade": "Cancela la suscripción para cambiar a Gratis",
+    "subscribe": "Suscribirse",
+    "manageSubscriptionBilling": "Gestionar Suscripción y Facturación",
+    "stripePowered": "Pagos seguros con Stripe"
   },
   "leaderboard": {
     "title": "Clasificación de modelos",
@@ -1155,6 +1335,42 @@
   "modeToggle": {
     "quick": "Rápido",
     "fullCouncil": "Consejo Completo"
+  },
+  "commandPalette": {
+    "placeholder": "Escribe un comando o busca...",
+    "navigation": "Navegación",
+    "create": "Crear",
+    "recentConversations": "Conversaciones Recientes",
+    "theme": "Tema",
+    "actions": {
+      "openSettings": "Abrir Configuración",
+      "openSettingsDesc": "Perfil, facturación, equipo, claves API",
+      "openMyCompany": "Abrir Mi Empresa",
+      "openMyCompanyDesc": "Departamentos, roles, playbooks, decisiones",
+      "openLeaderboard": "Abrir Clasificación",
+      "openLeaderboardDesc": "Rankings de rendimiento de modelos",
+      "openLLMHub": "Abrir Hub de LLM",
+      "openLLMHubDesc": "Configurar modelos de IA y presets",
+      "newSession": "Nueva Sesión de Consejo",
+      "newSessionDesc": "Iniciar una nueva deliberación del consejo de IA",
+      "untitledConversation": "Conversación sin título",
+      "switchToProject": "Cambiar a: {{name}}",
+      "clearProject": "Limpiar Selección de Proyecto",
+      "clearProjectDesc": "Quitar contexto de proyecto de las conversaciones",
+      "lightMode": "Cambiar a Modo Claro",
+      "darkMode": "Cambiar a Modo Oscuro",
+      "systemTheme": "Usar Tema del Sistema",
+      "systemThemeDesc": "Coincide con la preferencia de tu SO"
+    }
+  },
+  "contextMenu": {
+    "conversationActions": "Acciones de conversación",
+    "rename": "Renombrar",
+    "addStar": "Añadir estrella",
+    "removeStar": "Quitar estrella",
+    "archive": "Archivar",
+    "unarchive": "Desarchivar",
+    "export": "Exportar"
   },
   "validation": {
     "required": "Este campo es requerido",
@@ -1314,6 +1530,8 @@
     "avgTokensPerSession": "Tokens promedio/sesión",
     "rankingParseRate": "Tasa de parseo de ranking",
     "inputTokens": "Tokens de entrada",
-    "outputTokens": "Tokens de salida"
+    "outputTokens": "Tokens de salida",
+    "loadingTeam": "Cargando equipo...",
+    "joined": "Se unió"
   }
 }


### PR DESCRIPTION
## Summary

Expands internationalization (i18n) support across the application by replacing hardcoded English strings with translation keys, enabling proper multi-language support.

### Components Updated

- **Theme Toggle** - Light/dark/system labels and accessibility descriptions
- **AI Write Assist** - Context-specific button text and placeholder hints for all content types
- **Quick Action Chips** - Landing page prompts
- **Sidebar** - Toast messages, sort options, filter labels, context menu actions
- **Command Palette** - Search placeholders, group labels, action descriptions
- **Conversation Context** - Delete/restore toast messages with undo functionality
- **Playbook Dropdown** - Stage 3 selection UI labels
- **Members Tab** - Team management strings and role descriptions

### Translation Files

- `en.json` - English translations (230+ new keys)
- `es.json` - Spanish translations (230+ new keys)

### Technical Details

- Uses `react-i18next` `useTranslation` hook consistently
- Proper dependency arrays in `useCallback`/`useMemo` include `t` function
- Context-aware translations for AI Write Assist based on content type
- Pluralization support for bulk operations (e.g., "{{count}} conversations deleted")

## Test plan

- [x] Verify all translated strings display correctly in English
- [x] Switch to Spanish locale and verify translations
- [x] Test AI Write Assist button text changes per context type
- [ ] Test toast messages for conversation delete/restore with undo (requires deleting conversation)
- [x] Verify Command Palette labels and placeholders
- [x] Test theme toggle accessibility labels (Light → Dark → System cycle)

### Verified via Chrome DevTools MCP:
- Theme toggle cycles correctly with translated labels: "Light", "Dark", "System (Dark/Light)"
- Spanish locale shows all UI elements translated: "La única IA en la que confiar", "IAs", "rondas", "Nueva conversación", etc.
- Command Palette shows "Type a command or search...", "NAVIGATION", "CREATE" group headers
- New Department modal shows translated AI assist text

🤖 Generated with [Claude Code](https://claude.com/claude-code)