### PR TITLE
feat(devops): add feature flags system for runtime toggles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1041,6 +1041,81 @@ Enables Claude to read browser console logs, network requests, and take screensh
 4. **Resilience patterns** - Circuit breaker, timeouts, graceful degradation
 5. **Mobile-first** - Base styles for mobile, enhanced on desktop
 
+## Feature Flags
+
+Runtime toggles for gradual rollouts, A/B testing, and kill switches.
+
+### Backend Usage
+
+```python
+from backend.feature_flags import is_enabled, get_flags
+
+# Check a single flag
+if is_enabled("advanced_search"):
+    # use advanced search logic
+
+# Get all flags
+flags = get_flags()  # {"prompt_caching": True, "advanced_search": False, ...}
+```
+
+### Frontend Usage
+
+```tsx
+import { useFeatureFlags } from './hooks';
+
+function MyComponent() {
+  const { flags, isEnabled } = useFeatureFlags();
+
+  // Check a specific flag
+  if (isEnabled('command_palette')) {
+    return <CommandPalette />;
+  }
+
+  // Or use flags directly
+  return flags.dark_mode ? <DarkUI /> : <LightUI />;
+}
+```
+
+### API Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/feature-flags` | Get all flags `{flags: {name: bool}}` |
+| `GET /api/feature-flags/definitions` | Get flags with metadata (for admin UI) |
+
+### Adding New Flags
+
+1. Add to `FEATURE_FLAG_DEFINITIONS` in `backend/feature_flags.py`:
+   ```python
+   "my_new_feature": (
+       "FLAG_MY_NEW_FEATURE",  # env var name
+       False,                   # default value
+       "Description of feature" # for admin UI
+   ),
+   ```
+
+2. Set in `.env` or environment:
+   ```
+   FLAG_MY_NEW_FEATURE=true
+   ```
+
+3. Use in code (backend or frontend)
+
+### Current Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `prompt_caching` | true | LLM prompt caching for cost savings |
+| `stage2_ranking` | true | Stage 2 peer ranking |
+| `streaming_responses` | true | Streaming token responses |
+| `command_palette` | true | Cmd+K command palette |
+| `dark_mode` | true | Dark mode toggle |
+| `advanced_search` | false | Semantic search in knowledge base |
+| `multi_company` | false | Multi-company switching |
+| `export_pdf` | false | PDF export of conversations |
+| `gpt5_model` | true | GPT-5 model in council |
+| `claude_opus` | true | Claude Opus model in council |
+
 ## LLM Model Configuration
 
 ### Model Registry

--- a/backend/feature_flags.py
+++ b/backend/feature_flags.py
@@ -1,0 +1,192 @@
+"""
+Feature Flags Module - Runtime toggles for gradual rollouts and kill switches.
+
+Phase 1: Environment variable based flags (simple, no database required)
+
+Usage:
+    from backend.feature_flags import get_flags, is_enabled
+
+    # Check a single flag
+    if is_enabled("new_council_ui"):
+        # use new UI logic
+
+    # Get all flags (for API response)
+    flags = get_flags()
+
+Environment Variables:
+    FLAG_<NAME>=true|false
+
+    Examples:
+        FLAG_NEW_COUNCIL_UI=true
+        FLAG_ADVANCED_SEARCH=false
+        FLAG_GPT5_MODEL=true
+
+Adding New Flags:
+    1. Add to FEATURE_FLAGS dict below with default value
+    2. Document purpose in comment
+    3. Frontend reads via /api/feature-flags endpoint
+"""
+
+import os
+from typing import Dict
+
+# =============================================================================
+# FEATURE FLAG DEFINITIONS
+# =============================================================================
+# Format: "flag_name": (env_var_name, default_value, description)
+#
+# Naming conventions:
+# - Use snake_case for flag names
+# - Prefix env vars with FLAG_
+# - Default to False for new/experimental features
+# - Default to True for existing features you might need to disable
+# =============================================================================
+
+FEATURE_FLAG_DEFINITIONS: Dict[str, tuple[str, bool, str]] = {
+    # Council Features
+    "prompt_caching": (
+        "ENABLE_PROMPT_CACHING",  # Uses existing env var
+        True,
+        "Enable LLM prompt caching for cost savings"
+    ),
+    "stage2_ranking": (
+        "FLAG_STAGE2_RANKING",
+        True,
+        "Enable Stage 2 peer ranking (disable to skip to synthesis)"
+    ),
+    "streaming_responses": (
+        "FLAG_STREAMING_RESPONSES",
+        True,
+        "Enable streaming token responses (disable for batch mode)"
+    ),
+
+    # UI Features
+    "command_palette": (
+        "FLAG_COMMAND_PALETTE",
+        True,
+        "Enable Cmd+K command palette"
+    ),
+    "dark_mode": (
+        "FLAG_DARK_MODE",
+        True,
+        "Enable dark mode toggle"
+    ),
+
+    # Experimental Features (default off)
+    "advanced_search": (
+        "FLAG_ADVANCED_SEARCH",
+        False,
+        "Enable semantic search in knowledge base"
+    ),
+    "multi_company": (
+        "FLAG_MULTI_COMPANY",
+        False,
+        "Enable multi-company switching for users"
+    ),
+    "export_pdf": (
+        "FLAG_EXPORT_PDF",
+        False,
+        "Enable PDF export of council conversations"
+    ),
+
+    # Model Features
+    "gpt5_model": (
+        "FLAG_GPT5_MODEL",
+        True,
+        "Enable GPT-5 model in council (disable if API issues)"
+    ),
+    "claude_opus": (
+        "FLAG_CLAUDE_OPUS",
+        True,
+        "Enable Claude Opus model in council"
+    ),
+}
+
+
+def _load_flags() -> Dict[str, bool]:
+    """Load all feature flags from environment variables."""
+    flags = {}
+    for flag_name, (env_var, default, _description) in FEATURE_FLAG_DEFINITIONS.items():
+        env_value = os.getenv(env_var, "").lower()
+        if env_value in ("true", "1", "yes", "on"):
+            flags[flag_name] = True
+        elif env_value in ("false", "0", "no", "off"):
+            flags[flag_name] = False
+        else:
+            flags[flag_name] = default
+    return flags
+
+
+# Load flags at module import (cached)
+_FLAGS: Dict[str, bool] = _load_flags()
+
+
+def get_flags() -> Dict[str, bool]:
+    """
+    Get all feature flags.
+
+    Returns:
+        Dict mapping flag names to their boolean values.
+
+    Example:
+        >>> get_flags()
+        {'prompt_caching': True, 'advanced_search': False, ...}
+    """
+    return _FLAGS.copy()
+
+
+def is_enabled(flag_name: str) -> bool:
+    """
+    Check if a specific feature flag is enabled.
+
+    Args:
+        flag_name: The name of the flag to check (e.g., "advanced_search")
+
+    Returns:
+        True if the flag is enabled, False otherwise.
+        Returns False for unknown flags (fail-safe).
+
+    Example:
+        >>> is_enabled("prompt_caching")
+        True
+        >>> is_enabled("nonexistent_flag")
+        False
+    """
+    return _FLAGS.get(flag_name, False)
+
+
+def reload_flags() -> Dict[str, bool]:
+    """
+    Reload flags from environment variables.
+
+    Use this if environment variables have changed at runtime
+    (e.g., in tests or after config reload).
+
+    Returns:
+        Updated flags dictionary.
+    """
+    global _FLAGS
+    _FLAGS = _load_flags()
+    return _FLAGS
+
+
+def get_flag_definitions() -> Dict[str, dict]:
+    """
+    Get flag definitions with metadata (for admin UI).
+
+    Returns:
+        Dict with flag names as keys and metadata dicts as values.
+
+    Example:
+        >>> get_flag_definitions()["advanced_search"]
+        {'env_var': 'FLAG_ADVANCED_SEARCH', 'default': False, 'description': '...'}
+    """
+    return {
+        name: {
+            "env_var": env_var,
+            "default": default,
+            "description": description,
+            "current": _FLAGS.get(name, default),
+        }
+        for name, (env_var, default, description) in FEATURE_FLAG_DEFINITIONS.items()
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -751,6 +751,40 @@ async def root():
     return {"status": "ok", "service": "LLM Council API"}
 
 
+@app.get("/api/feature-flags")
+async def get_feature_flags():
+    """
+    Get all feature flags.
+
+    Returns current state of all feature flags for the frontend to consume.
+    Flags are read from environment variables at startup.
+
+    Returns:
+        {"flags": {"flag_name": bool, ...}}
+    """
+    try:
+        from .feature_flags import get_flags
+    except ImportError:
+        from backend.feature_flags import get_flags
+
+    return {"flags": get_flags()}
+
+
+@app.get("/api/feature-flags/definitions")
+async def get_feature_flag_definitions():
+    """
+    Get feature flag definitions with metadata (for admin/debug UI).
+
+    Returns flag names, descriptions, defaults, and current values.
+    """
+    try:
+        from .feature_flags import get_flag_definitions
+    except ImportError:
+        from backend.feature_flags import get_flag_definitions
+
+    return {"definitions": get_flag_definitions()}
+
+
 @app.get("/health")
 async def health_check():
     """

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3377,6 +3377,24 @@ export const api = {
     }
     return response.json();
   },
+
+  // ===========================================================================
+  // FEATURE FLAGS
+  // ===========================================================================
+
+  /**
+   * Get all feature flags.
+   * Returns current state of all feature flags for conditional rendering.
+   * No authentication required - flags are public.
+   */
+  async getFeatureFlags(): Promise<{ flags: Record<string, boolean> }> {
+    const response = await fetch(`${API_BASE}/api/feature-flags`);
+    if (!response.ok) {
+      // Return empty flags on error (fail open)
+      return { flags: {} };
+    }
+    return response.json();
+  },
 };
 
 // =============================================================================

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -9,6 +9,7 @@ export * from './queries';
 
 // App-level state hooks
 export { useMessageStreaming } from './useMessageStreaming';
+export { useFeatureFlags } from './useFeatureFlags';
 export { useBulkConversationActions } from './useBulkConversationActions';
 export { useTriage } from './useTriage';
 export { usePrefetchCompany, usePrefetchConversation } from './usePrefetch';
@@ -56,3 +57,4 @@ export type {
 } from './useMessageStreaming';
 export type { UseBulkConversationActionsOptions } from './useBulkConversationActions';
 export type { UseTriageOptions } from './useTriage';
+export type { FeatureFlags, FeatureFlagName } from './useFeatureFlags';

--- a/frontend/src/hooks/useFeatureFlags.ts
+++ b/frontend/src/hooks/useFeatureFlags.ts
@@ -1,0 +1,87 @@
+/**
+ * Feature Flags Hook
+ *
+ * Provides access to feature flags for conditional rendering.
+ * Flags are fetched once on app load and cached.
+ *
+ * Usage:
+ *   const { flags, isEnabled, isLoading } = useFeatureFlags();
+ *
+ *   // Check a specific flag
+ *   if (isEnabled('advanced_search')) {
+ *     // render advanced search UI
+ *   }
+ *
+ *   // Or use flags directly
+ *   {flags.command_palette && <CommandPalette />}
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../api';
+
+// Default flags to use before fetch completes or on error
+const DEFAULT_FLAGS: Record<string, boolean> = {
+  prompt_caching: true,
+  stage2_ranking: true,
+  streaming_responses: true,
+  command_palette: true,
+  dark_mode: true,
+  advanced_search: false,
+  multi_company: false,
+  export_pdf: false,
+  gpt5_model: true,
+  claude_opus: true,
+};
+
+export const featureFlagKeys = {
+  all: ['feature-flags'] as const,
+};
+
+/**
+ * Hook to access feature flags.
+ *
+ * @returns {Object} Feature flag state and helpers
+ * @returns {Record<string, boolean>} flags - All flags as a key-value object
+ * @returns {function} isEnabled - Check if a specific flag is enabled
+ * @returns {boolean} isLoading - True while fetching flags
+ * @returns {boolean} isError - True if fetch failed
+ */
+export function useFeatureFlags() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: featureFlagKeys.all,
+    queryFn: () => api.getFeatureFlags(),
+    staleTime: 5 * 60 * 1000, // 5 minutes - flags don't change often
+    gcTime: 30 * 60 * 1000, // 30 minutes cache
+    retry: 1, // Only retry once on failure
+    refetchOnWindowFocus: false, // Don't refetch on tab focus
+  });
+
+  // Merge fetched flags with defaults (fetched values take precedence)
+  const flags: Record<string, boolean> = {
+    ...DEFAULT_FLAGS,
+    ...(data?.flags || {}),
+  };
+
+  /**
+   * Check if a specific feature flag is enabled.
+   *
+   * @param flagName - The name of the flag to check
+   * @returns True if enabled, false otherwise (including unknown flags)
+   */
+  const isEnabled = (flagName: string): boolean => {
+    return flags[flagName] ?? false;
+  };
+
+  return {
+    flags,
+    isEnabled,
+    isLoading,
+    isError,
+  };
+}
+
+// Type for the flags object
+export type FeatureFlags = typeof DEFAULT_FLAGS;
+
+// Export individual flag names for type safety
+export type FeatureFlagName = keyof FeatureFlags;


### PR DESCRIPTION
## Summary
- Add environment variable-based feature flags system
- Backend module with flag definitions and API endpoints
- Frontend hook for conditional rendering
- Full documentation in CLAUDE.md

## From DevOps Audit
This implements **Phase 1 Feature Flags** from the [DevOps audit](audits/devops-audit-2026-01-12.md):
> Enables gradual rollouts, A/B testing, and quick kill switches.

## Files Changed
| File | Purpose |
|------|---------|
| `backend/feature_flags.py` | Flag definitions and helpers |
| `backend/main.py` | API endpoints |
| `frontend/src/api.ts` | API client method |
| `frontend/src/hooks/useFeatureFlags.ts` | React hook |
| `CLAUDE.md` | Documentation |

## Usage

**Backend:**
```python
from backend.feature_flags import is_enabled
if is_enabled("advanced_search"):
    # use advanced search
```

**Frontend:**
```tsx
const { isEnabled } = useFeatureFlags();
if (isEnabled('command_palette')) {
    return <CommandPalette />;
}
```

**Set flags via environment:**
```
FLAG_ADVANCED_SEARCH=true
FLAG_EXPORT_PDF=false
```

## Test plan
- [ ] TypeScript compiles
- [ ] ESLint passes
- [ ] Backend starts without errors
- [ ] `GET /api/feature-flags` returns flags
- [ ] Frontend hook loads flags

---
Generated with [Claude Code](https://claude.com/claude-code)