### PR TITLE
fix(ui): prevent false error detection in LLM responses

### DIFF
--- a/frontend/src/components/Stage1.tsx
+++ b/frontend/src/components/Stage1.tsx
@@ -450,16 +450,21 @@ function Stage1({
   const displayData: Stage1DisplayData[] = [];
 
   // Helper to detect if response text looks like an error message
+  // IMPORTANT: Only match actual error message patterns from backend, not content
+  // that discusses these topics. Backend errors use formats like "[Error: ...]"
+  // or "Model timeout after Xs". See backend/council.py for error formats.
   const textLooksLikeError = (text: string): boolean => {
     if (!text) return false;
     const lower = text.toLowerCase();
     return (
-      lower.includes('[error:') ||
-      lower.includes('status 429') ||
-      lower.includes('rate limit') ||
-      lower.includes('api error') ||
-      lower.includes('timeout') ||
-      lower.includes('service unavailable')
+      lower.includes('[error:') || // Backend error wrapper format
+      lower.includes('[error]') || // Alternative error wrapper
+      lower.includes('status 429') || // HTTP 429 (specific enough)
+      lower.includes('rate limit exceeded') || // Full phrase, not just "rate limit"
+      lower.includes('model timeout') || // Our specific timeout format
+      lower.includes('timeout after') || // "timeout after 60s" pattern
+      lower.includes('503 service') || // HTTP 503 error
+      lower.includes('api request failed') // Explicit failure message
     );
   };
 

--- a/frontend/src/components/Stage2.tsx
+++ b/frontend/src/components/Stage2.tsx
@@ -89,16 +89,21 @@ function Stage2({
   const displayData: Stage2DisplayData[] = [];
 
   // Helper to detect if response text looks like an error message
+  // IMPORTANT: Only match actual error message patterns from backend, not content
+  // that discusses these topics. Backend errors use formats like "[Error: ...]"
+  // or "Model timeout after Xs". See backend/council.py for error formats.
   const textLooksLikeError = (text: string): boolean => {
     if (!text) return false;
     const lower = text.toLowerCase();
     return (
-      lower.includes('[error:') ||
-      lower.includes('status 429') ||
-      lower.includes('rate limit') ||
-      lower.includes('api error') ||
-      lower.includes('timeout') ||
-      lower.includes('service unavailable')
+      lower.includes('[error:') || // Backend error wrapper format
+      lower.includes('[error]') || // Alternative error wrapper
+      lower.includes('status 429') || // HTTP 429 (specific enough)
+      lower.includes('rate limit exceeded') || // Full phrase, not just "rate limit"
+      lower.includes('model timeout') || // Our specific timeout format
+      lower.includes('timeout after') || // "timeout after 60s" pattern
+      lower.includes('503 service') || // HTTP 503 error
+      lower.includes('api request failed') // Explicit failure message
     );
   };
 


### PR DESCRIPTION
## Summary
- Fixed `textLooksLikeError` function in Stage1 and Stage2 that was incorrectly flagging legitimate LLM responses as errors
- Responses discussing "rate limits", "timeouts", or "API errors" as technical topics were being rendered as raw text with error styling instead of Markdown

## Root Cause
The error detection patterns were too broad:
- `rate limit` matched "discusses rate limits" ❌
- `timeout` matched "implements timeout handling" ❌  
- `api error` matched "good API error handling" ❌

## Solution
Made patterns match actual backend error formats from `council.py` and `openrouter.py`:
- `rate limit` → `rate limit exceeded`
- `timeout` → `model timeout` or `timeout after`
- Removed generic `api error` (real errors use `[Error:]` wrapper)
- Added `[error]`, `503 service`, `api request failed` patterns

## Test Results
| Input | Before | After |
|-------|--------|-------|
| `[Error: Model timeout]` | ✅ Error | ✅ Error |
| `[Error: Status 429]` | ✅ Error | ✅ Error |
| `discusses rate limits` | ❌ Error | ✅ Normal |
| `timeout handling` | ❌ Error | ✅ Normal |

## Test plan
- [x] TypeScript compiles
- [x] ESLint passes (0 errors on changed files)
- [x] All 145 frontend tests pass
- [x] All 333 backend tests pass
- [x] Production build succeeds
- [x] Pattern logic verified with test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)