### PR TITLE
fix(billing): make query increment non-blocking to prevent stream failures

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -166,7 +166,8 @@ STAGE3_TIMEOUT = int(os.getenv("STAGE3_TIMEOUT", "120"))  # 120s for chairman sy
 
 # Per-model timeout - individual models that hang get marked as error
 # This catches truly stuck models without cancelling healthy ones
-PER_MODEL_TIMEOUT = int(os.getenv("PER_MODEL_TIMEOUT", "60"))  # 60s per individual model
+# NOTE: 90s gives slower models like Grok-4 sufficient time while still catching stuck requests
+PER_MODEL_TIMEOUT = int(os.getenv("PER_MODEL_TIMEOUT", "90"))  # 90s per individual model
 
 # Require access_token for RLS-protected queries (recommended: true in production)
 # When false, falls back to service client (bypasses RLS) - only for backwards compat

--- a/backend/tests/test_billing.py
+++ b/backend/tests/test_billing.py
@@ -328,18 +328,30 @@ class TestIncrementQueryUsage:
             mock_client.rpc.assert_called_once_with('increment_query_usage', {'p_user_id': 'user-123'})
             assert result == 51
 
-    def test_raises_when_service_unavailable(self):
-        """Should raise when service client unavailable."""
+    def test_returns_negative_when_service_unavailable(self):
+        """Should return -1 when service client unavailable (non-blocking by default)."""
         with patch('backend.billing.get_supabase_service') as mock_service:
             with patch('backend.billing.log_billing_event'):
                 mock_service.return_value = None
 
-                # Should return 0 when service unavailable
+                # Default behavior: returns -1 to not block the user experience
                 result = increment_query_usage("user-123")
-                assert result == 0
+                assert result == -1
 
-    def test_raises_on_rpc_failure(self):
-        """Should raise ValueError when RPC fails (security measure)."""
+    def test_returns_negative_on_rpc_failure(self):
+        """Should return -1 when RPC fails (non-blocking by default)."""
+        with patch('backend.billing.get_supabase_service') as mock_service:
+            with patch('backend.billing.log_billing_event'):
+                mock_client = MagicMock()
+                mock_client.rpc.side_effect = Exception("RPC failed")
+                mock_service.return_value = mock_client
+
+                # Default behavior: returns -1 to not block the user experience
+                result = increment_query_usage("user-123")
+                assert result == -1
+
+    def test_raises_when_raise_on_failure_true(self):
+        """Should raise ValueError when raise_on_failure=True and RPC fails."""
         with patch('backend.billing.get_supabase_service') as mock_service:
             with patch('backend.billing.log_billing_event'):
                 mock_client = MagicMock()
@@ -347,7 +359,7 @@ class TestIncrementQueryUsage:
                 mock_service.return_value = mock_client
 
                 with pytest.raises(ValueError) as exc_info:
-                    increment_query_usage("user-123")
+                    increment_query_usage("user-123", raise_on_failure=True)
 
                 assert "unavailable" in str(exc_info.value).lower()
 


### PR DESCRIPTION
## Summary
- Make `increment_query_usage` non-blocking by default (returns -1 on failure instead of raising)
- Increase per-model timeout from 60s to 90s for slower models like Grok-4
- Update tests to reflect new behavior

## Problem
When the `increment_query_usage` RPC function doesn't exist in Supabase (migration not applied), it raises a `ValueError` that breaks the entire council stream, causing all LLM responses to fail with:
```
Query limit check unavailable - please try again
```

## Root Cause
The Sentry error shows the `increment_query_usage` RPC returns 404 because the migration `20251224110000_atomic_query_increment.sql` hasn't been applied to the production Supabase database.

## Solution
1. **Non-blocking billing**: `increment_query_usage` now returns -1 instead of raising by default
2. **Optional strict mode**: Added `raise_on_failure=True` parameter for cases needing enforcement
3. **Longer timeout**: Increased per-model timeout from 60s to 90s for slower models like Grok-4

## To Fully Fix
Apply this SQL to Supabase Dashboard → SQL Editor:
```sql
CREATE OR REPLACE FUNCTION increment_query_usage(p_user_id UUID)
RETURNS INTEGER AS $$
DECLARE
    v_new_count INTEGER;
BEGIN
    INSERT INTO user_profiles (user_id, queries_used_this_period, updated_at)
    VALUES (p_user_id, 1, NOW())
    ON CONFLICT (user_id) DO UPDATE
    SET
        queries_used_this_period = COALESCE(user_profiles.queries_used_this_period, 0) + 1,
        updated_at = NOW()
    RETURNING queries_used_this_period INTO v_new_count;
    RETURN v_new_count;
END;
$$ LANGUAGE plpgsql SECURITY DEFINER
SET search_path = '';

GRANT EXECUTE ON FUNCTION increment_query_usage(UUID) TO authenticated;
```

## Test plan
- [x] All 32 billing tests pass
- [ ] Deploy to Render
- [ ] Verify council streams work without RPC function
- [ ] Apply migration to Supabase
- [ ] Verify billing increment works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)