### PR TITLE
fix(i18n): prevent select dropdown text wrapping for long translations

### DIFF
--- a/frontend/src/components/ui/select.css
+++ b/frontend/src/components/ui/select.css
@@ -24,6 +24,11 @@
   cursor: pointer;
   transition: all 0.15s ease;
   outline: none;
+
+  /* Prevent text wrapping for long i18n strings */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .select-trigger:hover {
@@ -55,6 +60,15 @@
   height: 16px;
   opacity: 0.5;
   flex-shrink: 0;
+}
+
+/* SelectValue text - needs min-width: 0 to allow flex item truncation */
+.select-trigger > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary
- Fixed select dropdown text wrapping issue affecting long i18n strings (e.g., Spanish "Todas las conversaciones")
- Added text truncation properties to `.select-trigger` and inner text span
- Long text now truncates with ellipsis instead of breaking layout

## Test plan
- [ ] Switch language to Spanish in Settings
- [ ] Open sidebar and verify filter dropdown shows truncated text properly
- [ ] Verify no layout breakage in dropdown triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)