### PR TITLE
fix(mobile): context card depth effect and table horizontal scroll

### DIFF
--- a/frontend/src/components/MarkdownViewer.css
+++ b/frontend/src/components/MarkdownViewer.css
@@ -148,12 +148,44 @@
   font-family: inherit;
 }
 
+/* Tables - scrollable wrapper for mobile */
+.prose .table-scroll-wrapper {
+  display: block;
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+/* Scrollbar styling for table wrapper */
+.prose .table-scroll-wrapper::-webkit-scrollbar {
+  height: 6px;
+}
+
+.prose .table-scroll-wrapper::-webkit-scrollbar-track {
+  background: var(--color-bg-secondary);
+  border-radius: 3px;
+}
+
+.prose .table-scroll-wrapper::-webkit-scrollbar-thumb {
+  background: var(--color-border-dark);
+  border-radius: 3px;
+}
+
+.prose .table-scroll-wrapper::-webkit-scrollbar-thumb:hover {
+  background: var(--color-text-tertiary);
+}
+
 /* Tables - clean and readable */
 .prose table {
   font-size: 0.875rem;
   width: 100%;
-  margin-top: 1.25rem;
-  margin-bottom: 1.25rem;
+  min-width: max-content; /* Prevent columns from squishing on mobile */
+  margin: 0; /* Wrapper handles margins now */
   border-collapse: collapse;
   border-radius: var(--radius-md);
   overflow: hidden;
@@ -279,6 +311,18 @@
 }
 
 /* Tables - dark mode */
+.dark .prose .table-scroll-wrapper::-webkit-scrollbar-track {
+  background: var(--color-bg-tertiary);
+}
+
+.dark .prose .table-scroll-wrapper::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+}
+
+.dark .prose .table-scroll-wrapper::-webkit-scrollbar-thumb:hover {
+  background: var(--color-text-tertiary);
+}
+
 .dark .prose table {
   border-color: var(--color-border);
 }

--- a/frontend/src/components/MarkdownViewer.tsx
+++ b/frontend/src/components/MarkdownViewer.tsx
@@ -121,7 +121,18 @@ export default function MarkdownViewer({
       className={`prose prose-slate prose-sm max-w-none ${className}`}
       onClick={handleClick}
     >
-      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSlug]}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeSlug]}
+        components={{
+          // Wrap tables in a scrollable container for mobile
+          table: ({ children, ...props }) => (
+            <div className="table-scroll-wrapper">
+              <table {...props}>{children}</table>
+            </div>
+          ),
+        }}
+      >
         {displayContent}
       </ReactMarkdown>
     </div>

--- a/frontend/src/components/mycompany/styles/mobile.css
+++ b/frontend/src/components/mycompany/styles/mobile.css
@@ -872,12 +872,38 @@
   /* Context card - normal padding on mobile */
   .mc-context-card {
     padding: 16px;
+    padding-bottom: 3rem;
 
-    /* DEBUG: temporary visible background */
     background: var(--color-bg-primary);
-    border: 1px solid var(--color-border);
+    border: 1px solid var(--color-indigo-200);
+    border-top: 3px solid var(--color-indigo-400);
     border-radius: var(--radius-lg);
-    min-height: 150px;
+    /* Shadow must be preserved for depth effect */
+    box-shadow: var(--shadow-md);
+
+    /* Ensure card contains all content - no overflow clipping */
+    overflow: visible;
+
+    /* CRITICAL: Ensure card expands to fit ALL content */
+    flex-shrink: 0;
+    height: auto;
+    min-height: fit-content;
+  }
+
+  /* Content inside card must flow naturally - no constraints */
+  .mc-context-card .mc-context-content {
+    /* Ensure content is not constrained */
+    height: auto;
+    min-height: 0;
+    max-height: none;
+    overflow: visible;
+  }
+
+  /* MarkdownViewer prose inside card - ensure it renders fully */
+  .mc-context-card .prose {
+    /* Ensure all markdown content displays fully */
+    overflow: visible;
+    height: auto;
   }
 
   /* Empty context state in Overview - proper mobile layout */
@@ -1303,7 +1329,7 @@
   }
 
   .dark .mc-context-sticky-toolbar {
-    background: transparent;
+    background: var(--color-bg-secondary);
   }
 
   /* Hero section - dark mode on mobile */


### PR DESCRIPTION
## Summary

- **Context Card**: Fixed mobile shadow/depth effect not extending to cover all company overview content
- **Table Scroll**: Added horizontal scrolling for tables in markdown content to prevent overflow

## Problem

### Context Card Issue
On mobile, the `.mc-context-card` container's shadow/depth effect was visually ending partway through the document instead of wrapping all content. The card appeared to stop at the Table of Contents area, leaving the "Company Overview" content without the premium card styling.

### Table Overflow Issue
Tables in markdown content were overflowing their container on mobile/narrow viewports, breaking the layout instead of being horizontally scrollable.

## Solution

### Context Card Fix (`mobile.css`)
```css
.mc-context-card {
  flex-shrink: 0;
  height: auto;
  min-height: fit-content;
  overflow: visible;
  box-shadow: var(--shadow-md);
}
```

### Table Scroll Fix (`MarkdownViewer.tsx` + `MarkdownViewer.css`)
- Wrapped tables in `<div className="table-scroll-wrapper">` via ReactMarkdown components prop
- Added `overflow-x: auto` and `min-width: max-content` for proper horizontal scrolling
- Custom scrollbar styling with dark mode support

## Challenges & Lessons Learned

Initially struggled to identify the correct element causing the issue. Multiple attempts were made on wrong components (TOC dropdown, FAB button) before using **visual debugging** (red box-shadow) to confirm the `.mc-context-card` was the correct target.

**Key takeaway**: For CSS bugs that can't be directly observed, always use colored borders/shadows to visually confirm element identity before making changes.

## Test plan

- [ ] Verify context card shadow extends to bottom of all content on mobile
- [ ] Verify tables scroll horizontally without overflowing container
- [ ] Verify scrollbar styling in light and dark modes
- [ ] Test on various viewport widths (mobile, tablet, desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)