### PR TITLE
fix(openrouter): exclude Kimi and Grok from reasoning parameter

### DIFF
--- a/backend/openrouter.py
+++ b/backend/openrouter.py
@@ -608,11 +608,16 @@ async def query_model(
         payload["top_p"] = top_p
 
     # Only add reasoning parameter for models that support it
-    # Gemini 3 Pro has mandatory thinking that cannot be excluded - skip it
-    # Gemini 2.5 models use thinkingBudget instead of reasoning parameter
+    # - Gemini 3 Pro has mandatory thinking that cannot be excluded
+    # - Gemini 2.5 models use thinkingBudget instead of reasoning parameter
+    # - Kimi K2 does not support the reasoning parameter (causes 400 error)
+    # - Grok models do not support the reasoning parameter
     is_gemini_3 = "gemini-3" in model.lower()
     is_gemini_2_5 = "gemini-2.5" in model.lower()
-    if not is_gemini_3 and not is_gemini_2_5:
+    is_kimi = "kimi" in model.lower() or "moonshot" in model.lower()
+    is_grok = "grok" in model.lower()
+    supports_reasoning = not is_gemini_3 and not is_gemini_2_5 and not is_kimi and not is_grok
+    if supports_reasoning:
         # Exclude reasoning/thinking tokens from response - users should only see final answer
         # This affects reasoning models like o1, o3, GPT-5.1
         payload["reasoning"] = {"exclude": True}
@@ -741,11 +746,16 @@ async def query_model_stream(
         payload["top_p"] = top_p
 
     # Only add reasoning parameter for models that support it
-    # Gemini 3 Pro has mandatory thinking that cannot be excluded - skip it
-    # Gemini 2.5 models use thinkingBudget instead of reasoning parameter
+    # - Gemini 3 Pro has mandatory thinking that cannot be excluded
+    # - Gemini 2.5 models use thinkingBudget instead of reasoning parameter
+    # - Kimi K2 does not support the reasoning parameter (causes 400 error)
+    # - Grok models do not support the reasoning parameter
     is_gemini_3 = "gemini-3" in model.lower()
     is_gemini_2_5 = "gemini-2.5" in model.lower()
-    if not is_gemini_3 and not is_gemini_2_5:
+    is_kimi = "kimi" in model.lower() or "moonshot" in model.lower()
+    is_grok = "grok" in model.lower()
+    supports_reasoning = not is_gemini_3 and not is_gemini_2_5 and not is_kimi and not is_grok
+    if supports_reasoning:
         # Exclude reasoning/thinking tokens from response - users should only see final answer
         # This affects reasoning models like o1, o3, GPT-5.1
         payload["reasoning"] = {"exclude": True}


### PR DESCRIPTION
## Summary
- Fix 400 errors when calling Kimi K2 (`moonshotai/kimi-k2`) via OpenRouter
- Exclude Kimi and Grok models from the `reasoning` parameter which they don't support
- The `reasoning` parameter is specific to OpenAI reasoning models (o1, o3, GPT-5.1)

## Root Cause
We were sending `"reasoning": {"exclude": True}` to ALL models except Gemini. However, according to [OpenRouter's Kimi K2 documentation](https://openrouter.ai/moonshotai/kimi-k2), the model only supports:
- `max_tokens`, `temperature`, `top_p`, `frequency_penalty`, `presence_penalty`, `top_k`, `repetition_penalty`, `tools`, `tool_choice`

The unsupported `reasoning` parameter was causing 400 errors.

## Changes
- Added `is_kimi` check for models containing "kimi" or "moonshot"
- Added `is_grok` check for Grok models (also don't support reasoning)
- Updated `supports_reasoning` logic to exclude these models
- Applied fix to both `query_model()` and `query_model_stream()` functions

## Test plan
- [x] Backend tests pass (29/29 openrouter tests)
- [ ] Manual test: Run a council query with Kimi as stage2 reviewer
- [ ] Verify no more 400 errors from Kimi

## References
- [OpenRouter Kimi K2 Docs](https://openrouter.ai/moonshotai/kimi-k2)
- [Related GitHub Issue](https://github.com/continuedev/continue/issues/6619)

🤖 Generated with [Claude Code](https://claude.ai/code)