### PR TITLE
fix(mobile): remove header rounded corners to prevent white gaps

### DIFF
--- a/frontend/src/components/mycompany/styles/mobile.css
+++ b/frontend/src/components/mycompany/styles/mobile.css
@@ -1405,6 +1405,11 @@
     padding-top: 20px;
   }
 
+  /* Remove rounded corners on header - prevents white gaps at top corners on mobile */
+  .mc-header-dismissible {
+    border-radius: 0;
+  }
+
   /* Hide title row on mobile, just show company switcher */
   .mc-title-row {
     display: none;


### PR DESCRIPTION
## Summary
- Remove rounded top corners from Command Centre header on mobile
- Prevents white background from showing through at top-left and top-right corners

## Test plan
- [ ] Open Command Centre on mobile device
- [ ] Verify no white gaps visible at top corners of dark header

🤖 Generated with [Claude Code](https://claude.com/claude-code)