### PR TITLE
fix(mobile): align hero and context cards in company overview

### DIFF
--- a/frontend/src/components/mycompany/styles/mobile.css
+++ b/frontend/src/components/mycompany/styles/mobile.css
@@ -869,9 +869,9 @@
     gap: 12px;
   }
 
-  /* Context card - normal padding on mobile */
+  /* Context card - match hero padding for alignment */
   .mc-context-card {
-    padding: 16px;
+    padding: 16px 20px;
     padding-bottom: 3rem;
     background: var(--color-bg-primary);
     border: 1px solid var(--color-border);
@@ -888,6 +888,10 @@
     flex-shrink: 0;
     height: auto;
     min-height: fit-content;
+
+    /* Match hero: no margin on mobile */
+    margin: 0;
+    width: 100%;
   }
 
   /* Content inside card must flow naturally - no constraints */
@@ -943,11 +947,11 @@
   .mc-context-sticky-toolbar {
     background: var(--color-bg-primary);
     padding: 8px 0;
-    margin-left: -16px;
-    margin-right: -16px;
-    padding-left: 16px;
-    padding-right: 16px;
-    width: calc(100% + 32px);
+    margin-left: -20px;
+    margin-right: -20px;
+    padding-left: 20px;
+    padding-right: 20px;
+    width: calc(100% + 40px);
   }
 
   /* ========== PROJECTS TAB - MOBILE ========== */


### PR DESCRIPTION
## Summary
- Fixed alignment issue on Company Overview page where hero card content didn't align with context card content on mobile
- Matched context card styling to hero card: `margin: 0` and `width: 100%`
- Updated horizontal padding from 16px to 20px for consistent content alignment
- Adjusted sticky toolbar negative margins to match new padding

## Test plan
- [ ] Open Company Overview on mobile viewport (< 768px)
- [ ] Verify "AxCouncil Business Context" hero content aligns with "Table of Contents" content below
- [ ] Check sticky toolbar still spans full width when scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)