### PR TITLE
fix(ui): Unify OmniBar send button and fix mode toggle clicks

### DIFF
--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -302,8 +302,7 @@
 .messages-container > * {
   width: 100%;
   max-width: 72ch; /* ~680-720px based on typography - optimal reading width */
-  margin-inline-start: auto;
-  margin-inline-end: auto;
+  margin-inline: auto;
 }
 
 /* Scroll button is now fixed position, not in flow */
@@ -506,6 +505,7 @@
     16px,
     env(safe-area-inset-bottom, 16px)
   ); /* Safe area for notched devices */
+
   flex-shrink: 0;
   scrollbar-gutter: stable both-edges; /* Match messages-container for alignment */
 
@@ -522,8 +522,7 @@
   content: '';
   position: absolute;
   inset-block-start: -40px;
-  inset-inline-start: 0;
-  inset-inline-end: 0;
+  inset-inline: 0;
   height: 40px;
   background: linear-gradient(to bottom, transparent 0%, var(--color-bg-primary) 100%);
   pointer-events: none;
@@ -542,8 +541,7 @@
 .input-form > * {
   width: 100%;
   max-width: 72ch; /* Match reading column width */
-  margin-inline-start: auto;
-  margin-inline-end: auto;
+  margin-inline: auto;
 }
 
 /* Premium input wrapper - ChatGPT-style pill */
@@ -1090,10 +1088,9 @@ button.role-select-trigger:focus {
 .context-icon-btn.mode-toggle {
   margin-inline-start: 4px;
   border-inline-start: 1px solid var(--color-border-light);
-  padding-inline-start: 6px;
+  padding-inline: 6px 2px;
   border-radius: 0;
   width: auto;
-  padding-inline-end: 2px;
 }
 
 .context-icon-btn.mode-toggle.council {
@@ -2703,6 +2700,7 @@ button.mobile-role-select {
   gap: 2px;
   flex: 1;
   justify-content: flex-start;
+  pointer-events: auto; /* Ensure child buttons are clickable */
 }
 
 /* Textarea input - larger field for writing */
@@ -2890,6 +2888,11 @@ button.mobile-role-select {
   border: 1px solid var(--color-border-light);
   border-radius: 100px;
   margin-inline-start: 4px;
+
+  /* Ensure container allows clicks through */
+  position: relative;
+  z-index: 2;
+  pointer-events: auto;
 }
 
 .inline-mode-btn {
@@ -2903,6 +2906,15 @@ button.mobile-role-select {
   cursor: pointer;
   transition: all 0.15s ease;
   white-space: nowrap;
+
+  /* Ensure buttons are always clickable - explicit mobile touch handling */
+  position: relative;
+  z-index: 10;
+  pointer-events: auto;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  user-select: none;
 }
 
 .inline-mode-btn:hover:not(:disabled) {
@@ -2925,7 +2937,7 @@ button.mobile-role-select {
   color: var(--color-text-secondary);
 }
 
-/* Send button */
+/* Send button - matches OmniBar landing hero indigo style */
 .omni-send-btn {
   display: flex;
   align-items: center;
@@ -2934,9 +2946,9 @@ button.mobile-role-select {
   height: 32px;
   padding: 0;
   border: none;
-  border-radius: 50%;
-  background: var(--color-slate-200);
-  color: var(--color-slate-400);
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--color-text-tertiary);
   cursor: pointer;
   transition: all 0.15s ease;
   flex-shrink: 0;
@@ -2948,12 +2960,19 @@ button.mobile-role-select {
 }
 
 .omni-send-btn.active {
-  background: var(--color-slate-900);
+  background: var(--color-indigo-500);
   color: var(--color-text-inverse);
+  box-shadow: 0 2px 8px var(--overlay-indigo-30);
 }
 
-.omni-send-btn.active:hover {
-  background: var(--color-slate-700);
+.omni-send-btn.active:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: var(--color-indigo-600);
+  box-shadow: 0 4px 12px var(--overlay-indigo-40);
+}
+
+.omni-send-btn:active:not(:disabled) {
+  transform: translateY(0);
 }
 
 .omni-send-btn:disabled {
@@ -3115,17 +3134,13 @@ button.mobile-role-select {
 }
 
 .dark .omni-send-btn {
-  background: var(--color-slate-700);
-  color: var(--color-slate-500);
+  background: transparent;
+  color: var(--color-text-tertiary);
 }
 
 .dark .omni-send-btn.active {
-  background: var(--color-slate-100);
-  color: var(--color-slate-900);
-}
-
-.dark .omni-send-btn.active:hover {
-  background: var(--color-slate-200);
+  background: var(--color-brand-primary);
+  color: var(--color-text-inverse);
 }
 
 /* =============================================================================

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -22,6 +22,7 @@ import {
   ChevronRight,
   FolderKanban,
   RotateCcw,
+  Send,
 } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { BottomSheet } from '../ui/BottomSheet';
@@ -577,44 +578,68 @@ export function ChatInput({
                   )}
 
                 {/* Mode toggle - dynamic "1 AI / N AIs" pill based on LLM Hub config */}
-                <div
-                  className="omni-inline-mode-toggle"
-                  role="radiogroup"
-                  aria-label="Response mode"
-                >
-                  {withTooltip(
-                    <button
-                      type="button"
-                      className={cn(
-                        'inline-mode-btn no-touch-target',
-                        chatMode === 'chat' && 'active'
-                      )}
-                      onClick={() => !disabled && onChatModeChange?.('chat')}
-                      disabled={disabled}
-                      role="radio"
-                      aria-checked={chatMode === 'chat'}
-                    >
-                      1 AI
-                    </button>,
-                    TOOLTIPS.chatMode
-                  )}
-                  {withTooltip(
-                    <button
-                      type="button"
-                      className={cn(
-                        'inline-mode-btn no-touch-target',
-                        chatMode === 'council' && 'active'
-                      )}
-                      onClick={() => !disabled && onChatModeChange?.('council')}
-                      disabled={disabled}
-                      role="radio"
-                      aria-checked={chatMode === 'council'}
-                    >
-                      {aiCount} {aiCount === 1 ? 'AI' : 'AIs'}
-                    </button>,
-                    TOOLTIPS.councilMode
-                  )}
-                </div>
+                <Tooltip.Provider delayDuration={400}>
+                  <div
+                    className="omni-inline-mode-toggle"
+                    role="radiogroup"
+                    aria-label="Response mode"
+                  >
+                    <Tooltip.Root>
+                      <Tooltip.Trigger asChild>
+                        <button
+                          type="button"
+                          className={cn(
+                            'inline-mode-btn no-touch-target',
+                            chatMode === 'chat' && 'active'
+                          )}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (!disabled) onChatModeChange?.('chat');
+                          }}
+                          onPointerDown={(e) => e.stopPropagation()}
+                          disabled={disabled}
+                          role="radio"
+                          aria-checked={chatMode === 'chat'}
+                        >
+                          1 AI
+                        </button>
+                      </Tooltip.Trigger>
+                      <Tooltip.Portal>
+                        <Tooltip.Content className="tooltip-content" sideOffset={8}>
+                          {TOOLTIPS.chatMode}
+                          <Tooltip.Arrow className="tooltip-arrow" />
+                        </Tooltip.Content>
+                      </Tooltip.Portal>
+                    </Tooltip.Root>
+                    <Tooltip.Root>
+                      <Tooltip.Trigger asChild>
+                        <button
+                          type="button"
+                          className={cn(
+                            'inline-mode-btn no-touch-target',
+                            chatMode === 'council' && 'active'
+                          )}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (!disabled) onChatModeChange?.('council');
+                          }}
+                          onPointerDown={(e) => e.stopPropagation()}
+                          disabled={disabled}
+                          role="radio"
+                          aria-checked={chatMode === 'council'}
+                        >
+                          {aiCount} {aiCount === 1 ? 'AI' : 'AIs'}
+                        </button>
+                      </Tooltip.Trigger>
+                      <Tooltip.Portal>
+                        <Tooltip.Content className="tooltip-content" sideOffset={8}>
+                          {TOOLTIPS.councilMode}
+                          <Tooltip.Arrow className="tooltip-arrow" />
+                        </Tooltip.Content>
+                      </Tooltip.Portal>
+                    </Tooltip.Root>
+                  </div>
+                </Tooltip.Provider>
 
                 {/* Response Style Selector - Quick toggle for Precise/Balanced/Creative */}
                 {onSelectPreset && (
@@ -653,10 +678,7 @@ export function ChatInput({
                     onClick={onSubmit}
                     aria-label="Send message"
                   >
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
-                      <line x1="12" y1="19" x2="12" y2="5" />
-                      <polyline points="5 12 12 5 19 12" />
-                    </svg>
+                    <Send className="h-5 w-5" />
                   </button>,
                   TOOLTIPS.send
                 )}


### PR DESCRIPTION
## Summary

- **Send button icon**: Replace custom SVG arrow with Lucide `<Send>` icon in follow-up ChatInput to match the landing hero OmniBar
- **Send button colors**: Update from slate to indigo theme (`--color-indigo-500/600`) to match the system standard
- **Mode toggle fix**: Fix the 1 AI / 5 AIs toggle not responding to clicks on mobile

## Changes

### ChatInput.tsx
- Added `Send` import from lucide-react
- Replaced inline SVG with `<Send className="h-5 w-5" />`
- Restructured mode toggle to use explicit Tooltip structure instead of `withTooltip` wrapper
- Added `e.stopPropagation()` on both `onClick` and `onPointerDown` handlers

### ChatInterface.css
- Updated `.omni-send-btn.active` to use indigo colors with box-shadow
- Added hover lift effect matching OmniBar landing
- Updated dark mode styles to use `--color-brand-primary`
- Enhanced `.inline-mode-btn` with:
  - `pointer-events: auto`
  - Higher `z-index: 10`
  - `-webkit-touch-callout: none`
  - `user-select: none`

## Test plan
- [ ] Verify send button icon matches between landing hero and follow-up input
- [ ] Verify send button uses indigo color when active (not slate)
- [ ] Test 1 AI / 5 AIs toggle on mobile - should respond to taps
- [ ] Test mode toggle on desktop - should respond to clicks
- [ ] Verify dark mode styling is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)