### PR TITLE
fix(css): single source of truth for inline mode toggle classes

### DIFF
--- a/frontend/src/components/shared/OmniBar.css
+++ b/frontend/src/components/shared/OmniBar.css
@@ -147,7 +147,7 @@
 }
 
 /* Inner spans are visual indicators only (not clickable themselves) */
-.inline-mode-btn {
+.inline-mode-indicator {
   padding: 4px 10px;
   background: transparent;
   color: var(--color-text-tertiary);
@@ -159,7 +159,7 @@
   pointer-events: none; /* Not clickable - parent button handles clicks */
 }
 
-.inline-mode-btn.active {
+.inline-mode-indicator.active {
   background: var(--color-bg-primary);
   color: var(--color-text-primary);
   box-shadow: 0 1px 2px var(--overlay-black-10);
@@ -912,7 +912,7 @@
     padding: 2px;
   }
 
-  .inline-mode-btn {
+  .inline-mode-indicator {
     padding: 5px 10px;
     font-size: 11px;
     min-height: unset;
@@ -1156,11 +1156,11 @@
   border-color: var(--color-border-dark);
 }
 
-.dark .inline-mode-btn {
+.dark .inline-mode-indicator {
   color: var(--color-text-quaternary);
 }
 
-.dark .inline-mode-btn.active {
+.dark .inline-mode-indicator.active {
   background: var(--color-bg-tertiary);
   color: var(--color-text-primary);
   box-shadow: 0 1px 2px var(--overlay-black-20);

--- a/frontend/src/components/shared/OmniBar.tsx
+++ b/frontend/src/components/shared/OmniBar.tsx
@@ -797,7 +797,7 @@ export function OmniBar({
                   >
                     <span
                       className={cn(
-                        'inline-mode-btn no-touch-target',
+                        'inline-mode-indicator no-touch-target',
                         chatMode === 'chat' && 'active'
                       )}
                       aria-hidden="true"
@@ -806,7 +806,7 @@ export function OmniBar({
                     </span>
                     <span
                       className={cn(
-                        'inline-mode-btn no-touch-target',
+                        'inline-mode-indicator no-touch-target',
                         chatMode === 'council' && 'active'
                       )}
                       aria-hidden="true"


### PR DESCRIPTION
## Summary
- Renamed `.inline-mode-btn` to `.inline-mode-indicator` in OmniBar components
- Eliminates CSS cascade conflict where two files defined the same class with conflicting `pointer-events` values
- **OmniBar**: Uses `.inline-mode-indicator` for visual-only spans (`pointer-events: none`)
- **ChatInterface/ChatInput**: Uses `.inline-mode-btn` for clickable buttons (`pointer-events: auto`)

## Test plan
- [ ] Verify mode toggle (1 AI / 5 AIs) works in ChatInput follow-up flow
- [ ] Verify mode toggle appears correctly in OmniBar on landing page
- [ ] Test both desktop and mobile viewports
- [ ] Verify no CSS regression in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)