### PR TITLE
fix(mobile): Scroll input into view when keyboard appears

### DIFF
--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -7,7 +7,7 @@
  * Mom Test: Every icon has a clear tooltip explaining what it does
  */
 
-import { useState } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Popover from '@radix-ui/react-popover';
 import * as Tooltip from '@radix-ui/react-tooltip';
@@ -128,6 +128,9 @@ export function ChatInput({
   // Track which playbook sections are expanded (accordion within dropdown)
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({});
 
+  // Ref for textarea to scroll into view on focus
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
   // Get translated tooltips
   const TOOLTIPS = {
     projects: t('chat.tooltips.projects'),
@@ -196,6 +199,19 @@ export function ChatInput({
       : [...selectedPlaybooks, id];
     onSelectPlaybooks(newSelection);
   };
+
+  // Scroll input into view when focused on mobile (keyboard covers input otherwise)
+  const handleFocus = useCallback(() => {
+    if (isMobile) {
+      // Small delay to let keyboard start appearing
+      setTimeout(() => {
+        textareaRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+        });
+      }, 100);
+    }
+  }, [isMobile]);
 
   // Project list content - single select (radio-style)
   const projectList = (
@@ -489,6 +505,7 @@ export function ChatInput({
         {/* Top row: Just the textarea */}
         <div className="omni-top">
           <textarea
+            ref={textareaRef}
             id="chat-message-input"
             name="message"
             className="omni-input"
@@ -497,6 +514,7 @@ export function ChatInput({
             value={input}
             onChange={(e) => onInputChange(e.target.value)}
             onKeyDown={onKeyDown}
+            onFocus={handleFocus}
             onPaste={imageUpload.handlePaste}
             disabled={isLoading}
             rows={1}

--- a/frontend/src/components/shared/OmniBar.tsx
+++ b/frontend/src/components/shared/OmniBar.tsx
@@ -12,7 +12,7 @@
  * └──────────────────────────────────────────────────────┘
  */
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion, AnimatePresence } from 'framer-motion';
 import TextareaAutosize from 'react-textarea-autosize';
@@ -282,6 +282,19 @@ export function OmniBar({
       handleSubmit();
     }
   };
+
+  // Scroll input into view when focused on mobile (keyboard covers input otherwise)
+  const handleFocus = useCallback(() => {
+    if (isMobile) {
+      // Small delay to let keyboard start appearing
+      setTimeout(() => {
+        textareaRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+        });
+      }, 100);
+    }
+  }, [isMobile]);
 
   const currentPlaceholder =
     placeholder || (chatMode === 'chat' ? t('omnibar.placeholderChat') : t('omnibar.placeholder'));
@@ -672,6 +685,7 @@ export function OmniBar({
             value={value}
             onChange={(e) => onChange(e.target.value)}
             onKeyDown={handleKeyDown}
+            onFocus={handleFocus}
             placeholder={currentPlaceholder}
             className="omni-bar-input"
             minRows={1}


### PR DESCRIPTION
## Summary

- **Fix mobile UX issue** where virtual keyboard covers the input field when tapping OmniBar or follow-up chat input
- Add `onFocus` handlers that scroll the input into the center of the visible viewport
- Consistent fix applied to both `OmniBar.tsx` (landing page) and `ChatInput.tsx` (follow-up input)

## Problem

On mobile devices, when users tap on the OmniBar or follow-up chat input:
1. The virtual keyboard appears
2. The keyboard covers the input field
3. Users cannot see what they're typing without manually scrolling

This was a **code-level bug** - neither component had any focus handling to scroll the input into view.

## Solution

Added `onFocus` handlers to both input components:

```tsx
const handleFocus = useCallback(() => {
  if (isMobile) {
    setTimeout(() => {
      textareaRef.current?.scrollIntoView({
        behavior: 'smooth',
        block: 'center',
      });
    }, 100);
  }
}, [isMobile]);
```

**Why this approach:**
- `scrollIntoView` is the standard browser API for this use case
- `block: 'center'` positions the input in the middle of the viewport (above keyboard)
- 100ms delay allows the keyboard animation to begin before scrolling
- Only triggers on mobile (`isMobile` check) to avoid unnecessary scrolling on desktop
- Uses existing `isMobileDevice()` pattern already in the codebase

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/components/shared/OmniBar.tsx` | Added `useCallback` import, `handleFocus` callback, `onFocus` prop |
| `frontend/src/components/chat/ChatInput.tsx` | Added `useRef`, `useCallback` imports, `textareaRef`, `handleFocus` callback, `onFocus` prop |

## Test plan

- [x] TypeScript compiles
- [x] ESLint passes
- [x] Stylelint passes
- [x] Production build succeeds
- [ ] Test on mobile device or Chrome DevTools mobile emulation:
  - [ ] Tap OmniBar on landing page → keyboard appears → input scrolls to center
  - [ ] Navigate to chat with messages → tap follow-up input → keyboard appears → input scrolls to center

🤖 Generated with [Claude Code](https://claude.ai/code)