### PR TITLE
fix(ui): Team Tab UX improvements for clarity and consistency

### DIFF
--- a/frontend/src/components/mycompany/styles/shared.css
+++ b/frontend/src/components/mycompany/styles/shared.css
@@ -488,6 +488,9 @@
 
 /* Text button actions (Source, Promote, Delete) */
 .mc-text-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font-size: 12px;
   font-weight: 500;
   padding: 6px 12px;

--- a/frontend/src/components/mycompany/styles/shell/mobile/layout.css
+++ b/frontend/src/components/mycompany/styles/shell/mobile/layout.css
@@ -140,9 +140,9 @@
     padding: 4px 0;
   }
 
-  .mc-team-header span,
-  .mc-playbooks-header span,
-  .mc-decisions-header span {
+  .mc-team-header > span:first-child,
+  .mc-playbooks-header > span:first-child,
+  .mc-decisions-header > span:first-child {
     font-size: 0.75rem;
   }
 

--- a/frontend/src/components/mycompany/styles/tabs/overview/dark-mode.css
+++ b/frontend/src/components/mycompany/styles/tabs/overview/dark-mode.css
@@ -280,12 +280,12 @@
   border-block-end-color: var(--color-border);
 }
 
-.dark .mc-team-header span,
-.dark .mc-playbooks-header span,
-.dark .mc-decisions-header span,
-[data-theme='dark'] .mc-team-header span,
-[data-theme='dark'] .mc-playbooks-header span,
-[data-theme='dark'] .mc-decisions-header span {
+.dark .mc-team-header > span:first-child,
+.dark .mc-playbooks-header > span:first-child,
+.dark .mc-decisions-header > span:first-child,
+[data-theme='dark'] .mc-team-header > span:first-child,
+[data-theme='dark'] .mc-playbooks-header > span:first-child,
+[data-theme='dark'] .mc-decisions-header > span:first-child {
   color: var(--color-text-secondary);
 }
 

--- a/frontend/src/components/mycompany/styles/tabs/overview/search-filters.css
+++ b/frontend/src/components/mycompany/styles/tabs/overview/search-filters.css
@@ -17,9 +17,10 @@
   border-bottom: 1px solid var(--color-border);
 }
 
-.mc-team-header span,
-.mc-playbooks-header span,
-.mc-decisions-header span {
+/* Target only the stats text span, not button inner spans */
+.mc-team-header > span:first-child,
+.mc-playbooks-header > span:first-child,
+.mc-decisions-header > span:first-child {
   font-size: 0.8125rem;
   font-weight: 500;
   color: var(--color-text-secondary);

--- a/frontend/src/components/mycompany/tabs/TeamTab.tsx
+++ b/frontend/src/components/mycompany/tabs/TeamTab.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { Plus } from 'lucide-react';
+import { Plus, FileText } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { Button } from '../../ui/button';
 import { getDeptColor } from '../../../lib/colors';
@@ -225,13 +225,8 @@ export function TeamTab({
                         onViewDepartment && onViewDepartment(dept);
                       }}
                     >
-                      <span className="mc-context-icon">📄</span>
-                      <span>{t('mycompany.viewContext')}</span>
-                      {dept.context_md && (
-                        <span className="mc-context-size">
-                          {Math.round(dept.context_md.length / 1000)}k
-                        </span>
-                      )}
+                      <FileText size={14} className="mc-context-icon" />
+                      <span>{t('mycompany.aboutDepartment', { name: dept.name })}</span>
                     </button>
 
                     {/* Roles list */}
@@ -245,6 +240,7 @@ export function TeamTab({
                             onAddRole && onAddRole(dept.id);
                           }}
                         >
+                          <Plus size={14} />
                           {t('mycompany.newRole')}
                         </button>
                       </div>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -401,10 +401,13 @@
     "deletingConversations": "Deleting conversations",
     "deleteConversations": "Delete {{count}} conversation",
     "deleteConversations_other": "Delete {{count}} conversations",
+    "admin": "Admin",
+    "adminPortal": "Platform Admin Portal",
     "tooltips": {
       "company": "Departments, roles, playbooks",
       "settings": "Profile and preferences",
-      "signOut": "Sign out"
+      "signOut": "Sign out",
+      "admin": "Platform administration"
     }
   },
   "settings": {
@@ -1534,6 +1537,7 @@
     "departmentsRoles": "{{depts}} departments • {{roles}} roles",
     "roles": "roles",
     "viewContext": "View Guidelines",
+    "aboutDepartment": "About {{name}}",
     "rolesLabel": "Roles",
     "newRole": "New Role",
     "addRolesToDept": "Add roles to this department",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1483,6 +1483,7 @@
     "departmentsRoles": "{{depts}} departamentos • {{roles}} roles",
     "roles": "roles",
     "viewContext": "Ver Directrices",
+    "aboutDepartment": "Sobre {{name}}",
     "rolesLabel": "Roles",
     "newRole": "Nuevo Rol",
     "addRolesToDept": "Agregar roles a este departamento",


### PR DESCRIPTION
## Summary

Improves the Team tab UI to pass the "mom test" - making it self-explanatory without requiring technical knowledge.

### Changes

| Before | After |
|--------|-------|
| 📄 emoji icon | `FileText` Lucide icon (consistent with design system) |
| "View Guidelines" label | "About {department name}" (e.g., "About Marketing") |
| "1k" badge showing character count | Removed (confusing/meaningless to users) |
| "New Role" text only | "+ New Role" with Plus icon (more visible) |
| Button text dark on indigo background | White text (CSS specificity fix) |

### Problem Solved

Users (including the product owner) couldn't easily understand what UI elements meant:
- "View Guidelines" → Guidelines of what?
- "1k" → 1k what? Tokens? Characters? Dollars?
- "New Role" link → Easy to miss without icon

### Technical Details

- **Icon change**: Replaced hardcoded emoji with Lucide `FileText` component
- **CSS fix**: Changed `.mc-team-header span` selector to `.mc-team-header > span:first-child` to avoid overriding button inner spans
- **Flexbox**: Added `display: inline-flex` to `.mc-text-btn` for proper icon alignment

### Files Changed

- `TeamTab.tsx` - Component updates
- `en.json` / `es.json` - New translation key `aboutDepartment`
- `shared.css` - Flexbox for text buttons
- `search-filters.css`, `dark-mode.css`, `layout.css` - CSS specificity fixes

## Test Plan

- [ ] Verify "About {department}" label shows correctly for each department
- [ ] Verify "New Department" button has white text on indigo background
- [ ] Verify "+ New Role" shows icon inline with text
- [ ] Verify no "1k" badge appears
- [ ] Test in both light and dark mode
- [ ] Test on mobile viewport

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)