### PR TITLE
refactor(ui): Single source of truth for select/dropdown styling

### DIFF
--- a/frontend/src/components/ui/DepartmentSelect.css
+++ b/frontend/src/components/ui/DepartmentSelect.css
@@ -1,27 +1,26 @@
 /**
  * DepartmentSelect Styles
- * Uses CSS custom properties for department-specific colors
+ *
+ * IMPORTANT: Base trigger styling comes from select.css (single source of truth).
+ * This file contains ONLY department-specific additions:
+ * - Department color support via CSS custom properties
+ * - Selected state with department color
+ * - Dropdown items with department-specific hover/selected colors
  */
 
-/* Trigger button - inherits from save-dept-trigger when used in Stage3 */
+/* =============================================================================
+   TRIGGER ADDITIONS - Department color support
+   ============================================================================= */
+
+/* Department trigger extends base select-trigger--compact with color support */
 .dept-select-trigger {
-  display: inline-flex;
-  align-items: center;
+  /* Inherit from select-trigger--compact, add department-specific gap */
   gap: 6px;
-  padding: 6px 10px;
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-md);
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--color-slate-500);
-  cursor: pointer;
-  transition: all 0.15s ease;
 }
 
-/* When a department is selected, show its color */
+/* When a department is selected, show its color (overrides base styles) */
 .dept-select-trigger.has-selection {
-  border: 1px solid currentcolor;
+  /* Colors come from inline style: background, color, borderColor */
   opacity: 0.9;
 }
 
@@ -29,23 +28,9 @@
   opacity: 1;
 }
 
-.dept-select-trigger:hover:not(.has-selection) {
-  background: var(--color-bg-primary);
-  color: var(--color-gray-700);
-}
-
-.dept-select-trigger:focus {
-  outline: none;
-}
-
-.dept-select-trigger:focus:not(.has-selection) {
-  background: var(--color-bg-primary);
-}
-
-.dept-select-trigger[data-disabled] {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+/* =============================================================================
+   DROPDOWN CONTENT
+   ============================================================================= */
 
 /* Dropdown content - Design System compliant */
 .dept-select-content {
@@ -55,7 +40,7 @@
   min-width: 8rem;
   overflow: hidden;
   border-radius: var(--radius-lg);
-  border: 1px solid var(--color-gray-200);
+  border: 1px solid var(--color-border);
   background: var(--color-bg-primary);
   box-shadow: var(--shadow-lg);
 }
@@ -106,7 +91,11 @@
   min-width: var(--radix-select-trigger-width);
 }
 
-/* Individual items */
+/* =============================================================================
+   DROPDOWN ITEMS - Department color support
+   ============================================================================= */
+
+/* Individual items with department color support */
 .dept-select-item {
   position: relative;
   display: flex;
@@ -119,20 +108,20 @@
   padding-right: 36px;
   font-size: 14px;
   font-weight: 500;
-  color: var(--color-gray-700);
+  color: var(--color-text-primary);
   outline: none;
   transition: all 0.1s ease;
 }
 
 /* Hover state - uses CSS variable from inline style */
 .dept-select-item[data-highlighted] {
-  background: var(--dept-hover-bg, var(--color-gray-100));
+  background: var(--dept-hover-bg, var(--color-bg-hover));
 }
 
 /* Selected/checked state */
 .dept-select-item[data-state='checked'] {
-  background: var(--dept-checked-bg, var(--color-gray-100));
-  color: var(--dept-checked-text, var(--color-gray-700));
+  background: var(--dept-checked-bg, var(--color-bg-hover));
+  color: var(--dept-checked-text, var(--color-text-primary));
 }
 
 /* Disabled state */
@@ -150,7 +139,7 @@
   width: 16px;
   align-items: center;
   justify-content: center;
-  color: var(--dept-checked-text, var(--color-emerald-600));
+  color: var(--dept-checked-text, var(--color-indigo-500));
 }
 
 /* =============================================================================
@@ -177,20 +166,20 @@
   background: var(--color-bg-secondary);
   border-radius: var(--radius-lg);
   font-size: 16px;
-  color: var(--color-gray-700);
+  color: var(--color-text-primary);
   cursor: pointer;
   transition: all 0.15s ease;
   text-align: left;
 }
 
 .dept-select-item-mobile:active {
-  background: var(--color-gray-200);
+  background: var(--color-bg-tertiary);
   transform: scale(0.98);
 }
 
 .dept-select-item-mobile.selected {
-  background: var(--dept-bg, var(--color-gray-100));
-  color: var(--dept-text, var(--color-gray-700));
+  background: var(--dept-bg, var(--color-bg-hover));
+  color: var(--dept-text, var(--color-text-primary));
 }
 
 /* Radio indicator for single select */
@@ -200,7 +189,7 @@
   justify-content: center;
   width: 22px;
   height: 22px;
-  border: 2px solid var(--color-gray-300);
+  border: 2px solid var(--color-border);
   border-radius: 50%;
   background: var(--color-bg-primary);
   transition: all 0.1s ease;
@@ -208,8 +197,8 @@
 }
 
 .dept-select-radio.checked {
-  background: var(--radio-checked-bg, var(--color-gray-600));
-  border-color: var(--radio-checked-border, var(--color-gray-600));
+  background: var(--radio-checked-bg, var(--color-brand-primary));
+  border-color: var(--radio-checked-border, var(--color-brand-primary));
   color: var(--color-text-inverse);
 }
 
@@ -219,27 +208,9 @@
   font-weight: 500;
 }
 
-/* Mobile trigger improvements */
-@media (width <= 640px) {
-  .dept-select-trigger {
-    min-height: 44px;
-    padding: 10px 12px;
-    font-size: 15px;
-  }
-}
-
 /* =============================================================================
    DARK MODE
    ============================================================================= */
-
-.dark .dept-select-trigger {
-  color: var(--color-gray-400);
-}
-
-.dark .dept-select-trigger:hover:not(.has-selection) {
-  background: var(--color-bg-secondary);
-  color: var(--color-gray-200);
-}
 
 .dark .dept-select-content {
   background: var(--color-bg-secondary);
@@ -247,7 +218,7 @@
 }
 
 .dark .dept-select-item {
-  color: var(--color-gray-300);
+  color: var(--color-text-secondary);
 }
 
 .dark .dept-select-item[data-highlighted] {
@@ -256,7 +227,7 @@
 
 .dark .dept-select-item-mobile {
   background: var(--color-bg-tertiary);
-  color: var(--color-gray-300);
+  color: var(--color-text-secondary);
 }
 
 .dark .dept-select-item-mobile:active {

--- a/frontend/src/components/ui/DepartmentSelect.tsx
+++ b/frontend/src/components/ui/DepartmentSelect.tsx
@@ -27,7 +27,8 @@ import { getDeptColor } from '../../lib/colors';
 import { cn } from '../../lib/utils';
 import { BottomSheet } from './BottomSheet';
 import type { Department } from '../../types/business';
-import './DepartmentSelect.css';
+import './select.css'; // Base select styles - single source of truth
+import './DepartmentSelect.css'; // Department-specific additions only
 
 // Check if we're on mobile/tablet for bottom sheet vs dropdown
 const isMobileDevice = () => typeof window !== 'undefined' && window.innerWidth <= 768;
@@ -130,7 +131,11 @@ export function DepartmentSelect({
     return (
       <>
         <button
-          className={cn('dept-select-trigger', selectedColor && 'has-selection', className)}
+          className={cn(
+            'select-trigger select-trigger--compact dept-select-trigger',
+            selectedColor && 'has-selection',
+            className
+          )}
           disabled={disabled}
           onClick={() => setOpen(true)}
           style={triggerStyle}
@@ -183,7 +188,11 @@ export function DepartmentSelect({
   return (
     <SelectPrimitive.Root value={value || 'all'} onValueChange={onValueChange} disabled={disabled}>
       <SelectPrimitive.Trigger
-        className={cn('dept-select-trigger', selectedColor && 'has-selection', className)}
+        className={cn(
+          'select-trigger select-trigger--compact dept-select-trigger',
+          selectedColor && 'has-selection',
+          className
+        )}
         style={triggerStyle}
       >
         {showIcon && <Building2 className="h-3.5 w-3.5" />}

--- a/frontend/src/components/ui/MultiDepartmentSelect.css
+++ b/frontend/src/components/ui/MultiDepartmentSelect.css
@@ -1,53 +1,35 @@
 /**
  * MultiDepartmentSelect Styles
  *
- * Container and trigger styles only.
- * Item/checkbox styles are in DepartmentCheckboxItem.css (single source of truth).
+ * IMPORTANT: Base trigger styling comes from select.css (single source of truth).
+ * This file contains ONLY department-specific additions:
+ * - Color dots display
+ * - Placeholder/count text styling
+ * - Dropdown content styling
  */
 
 /* =============================================================================
-   TRIGGER BUTTON
+   TRIGGER ADDITIONS - Department-specific overrides on top of select-trigger
    ============================================================================= */
 
-/* Trigger button - matches toolbar-pill sizing for consistency */
+/* Override base select-trigger to allow content to determine width */
 .multi-dept-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 6px 10px;
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-md);
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--color-slate-500);
-  cursor: pointer;
-  transition: all 0.15s ease;
-  text-align: left;
-  white-space: nowrap;
-
-  /* Flex shrink support for responsive layouts */
+  /* Inherit from select-trigger, but allow flex content to size naturally */
+  width: auto;
   min-width: 0;
   flex-shrink: 1;
+
+  /* Custom gap for department content */
+  gap: 6px;
 }
 
-.multi-dept-trigger:hover:not(:disabled) {
-  background: var(--color-bg-primary);
-  color: var(--color-gray-700);
-}
-
-.multi-dept-trigger:focus {
-  outline: none;
-}
-
-.multi-dept-trigger[disabled] {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-/* Placeholder text */
+/* Placeholder text styling */
 .multi-dept-placeholder {
-  color: var(--color-slate-400);
+  color: var(--color-text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 /* Single department display */
@@ -56,7 +38,11 @@
   align-items: center;
   gap: 6px;
   font-weight: 500;
-  color: var(--color-slate-700);
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 /* Multiple departments count display */
@@ -65,7 +51,11 @@
   align-items: center;
   gap: 6px;
   font-weight: 500;
-  color: var(--color-slate-700);
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 /* Color dots container */
@@ -73,6 +63,7 @@
   display: inline-flex;
   align-items: center;
   gap: 2px;
+  flex-shrink: 0;
 }
 
 /* Individual color dot */
@@ -95,7 +86,7 @@
   max-height: 280px;
   overflow: hidden;
   border-radius: var(--radius-lg);
-  border: 1px solid var(--color-gray-200);
+  border: 1px solid var(--color-border);
   background: var(--color-bg-primary);
   box-shadow: var(--shadow-lg);
   animation: multiDeptIn 0.15s ease-out;
@@ -129,7 +120,7 @@
 .multi-dept-empty {
   padding: 12px;
   text-align: center;
-  color: var(--color-gray-400);
+  color: var(--color-text-tertiary);
   font-size: 13px;
 }
 
@@ -149,17 +140,8 @@
   touch-action: pan-y;
 }
 
-/* Mobile - ensure text truncation works */
+/* Mobile - smaller dots */
 @media (width <= 640px) {
-  .multi-dept-placeholder,
-  .multi-dept-single,
-  .multi-dept-count {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    min-width: 0;
-  }
-
   .multi-dept-dot {
     width: 7px;
     height: 7px;
@@ -169,20 +151,6 @@
 /* =============================================================================
    DARK MODE
    ============================================================================= */
-
-.dark .multi-dept-trigger {
-  background: transparent;
-  color: var(--color-text-tertiary);
-}
-
-.dark .multi-dept-trigger:hover:not(:disabled) {
-  background: var(--overlay-white-5);
-  color: var(--color-text-secondary);
-}
-
-.dark .multi-dept-trigger:focus {
-  outline: none;
-}
 
 .dark .multi-dept-placeholder {
   color: var(--color-text-tertiary);

--- a/frontend/src/components/ui/MultiDepartmentSelect.tsx
+++ b/frontend/src/components/ui/MultiDepartmentSelect.tsx
@@ -24,7 +24,8 @@ import { cn } from '../../lib/utils';
 import { BottomSheet } from './BottomSheet';
 import { DepartmentCheckboxItem } from './DepartmentCheckboxItem';
 import type { Department } from '../../types/business';
-import './MultiDepartmentSelect.css';
+import './select.css'; // Base select styles - single source of truth
+import './MultiDepartmentSelect.css'; // Department-specific additions only
 
 // Check if we're on mobile/tablet for bottom sheet vs dropdown
 // Use 768px to include tablets like iPad Mini
@@ -134,7 +135,7 @@ export function MultiDepartmentSelect({
       <>
         <button
           className={cn(
-            'multi-dept-trigger',
+            'select-trigger select-trigger--compact multi-dept-trigger',
             selectedDepts.length > 0 && 'has-selection',
             className
           )}
@@ -161,7 +162,11 @@ export function MultiDepartmentSelect({
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger
-        className={cn('multi-dept-trigger', selectedDepts.length > 0 && 'has-selection', className)}
+        className={cn(
+          'select-trigger select-trigger--compact multi-dept-trigger',
+          selectedDepts.length > 0 && 'has-selection',
+          className
+        )}
         disabled={disabled}
         title={tooltipText}
       >


### PR DESCRIPTION
## Summary

- **Establishes `select.css` as the single source of truth** for all dropdown/select trigger styling
- Department select components now inherit from base `select-trigger` class instead of defining conflicting custom styles
- Reduces CSS duplication by 47 lines while ensuring visual consistency

## Problem

Previously, there were 3 separate CSS implementations for select triggers:
- `select.css` - base select (with background, border, shadow)
- `MultiDepartmentSelect.css` - custom trigger (transparent, no border)
- `DepartmentSelect.css` - custom trigger (transparent, no border)

This caused visual inconsistency (some dropdowns had backgrounds, some didn't) and meant style changes required editing 3 files.

## Solution

| Before | After |
|--------|-------|
| 3 separate CSS files defining triggers | 1 source of truth (`select.css`) |
| Style change = edit 3 places | Style change = edit 1 place |
| Inconsistent appearance | Consistent appearance |
| Rebrand = weeks | Rebrand = hours |

## Changes

- `MultiDepartmentSelect.tsx` - Now uses `select-trigger select-trigger--compact` base classes
- `DepartmentSelect.tsx` - Now uses `select-trigger select-trigger--compact` base classes  
- `MultiDepartmentSelect.css` - Removed redundant base styles, kept department-specific additions only
- `DepartmentSelect.css` - Removed redundant base styles, kept department-specific additions only

## Test plan

- [ ] Verify "All departments" dropdown in Decisions tab has consistent styling (background, border)
- [ ] Verify department select in Stage 3 save dialog looks consistent
- [ ] Test dark mode appearance
- [ ] Test mobile view (bottom sheets should still work)

🤖 Generated with [Claude Code](https://claude.ai/code)