### PR TITLE
fix(deploy): Fix Render deployment by using dynamic PORT from environ…

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1043,4 +1043,6 @@ async def get_businesses(
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8081)
+    # Use PORT from environment (Render/cloud platforms) or default to 8081 for local dev
+    port = int(os.environ.get("PORT", 8081))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,24 @@
+services:
+  - type: web
+    name: axcouncil-backend
+    env: python
+    region: oregon
+    plan: free
+    buildCommand: "pip install --upgrade pip && pip install -e ."
+    startCommand: "python -m backend.main"
+    healthCheckPath: /health
+    envVars:
+      - key: PYTHON_VERSION
+        value: "3.10"
+      - key: ENVIRONMENT
+        value: production
+      # Add your other environment variables in the Render dashboard:
+      # - SUPABASE_URL
+      # - SUPABASE_SERVICE_KEY
+      # - OPENROUTER_API_KEY
+      # - REDIS_URL
+      # - QDRANT_URL
+      # - QDRANT_API_KEY
+      # - SENTRY_DSN
+      # - etc.
+    autoDeploy: true


### PR DESCRIPTION
…ment

CRITICAL FIX: Hardcoded port 8081 was causing all Render deployments to fail because Render assigns a dynamic PORT via environment variable.

Changes:
- backend/main.py: Use os.environ.get("PORT", 8081) instead of hardcoded 8081
  - Allows Render (and other cloud platforms) to assign port dynamically
  - Falls back to 8081 for local development
- Add render.yaml configuration file
  - Defines proper build and start commands
  - Sets health check path to /health
  - Specifies Python 3.10 runtime

How this fixes deployments:
1. Render assigns PORT (e.g., 10000) via environment
2. App now binds to the assigned PORT
3. Render's load balancer can reach the app
4. Health checks at /health succeed
5. Deployment marked as healthy ✅

Previously: App bound to 8081, Render expected dynamic PORT → health checks failed
Now: App uses Render's PORT → health checks succeed → deployment works

## Summary
<!-- Brief description of what this PR does -->

## Changes Made
- [ ] Change 1
- [ ] Change 2

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## Testing
- [ ] I have run `npm run lint` and fixed all errors
- [ ] I have run `npm run type-check` and fixed all errors
- [ ] I have run the test suite locally (`npm run test:run`)
- [ ] I have tested on mobile viewport (< 640px)
- [ ] I have tested dark mode (if UI changes)

## Screenshots (if applicable)
<!-- Add before/after screenshots for UI changes -->

## Checklist
- [ ] My code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged

---
*Automated checks will verify: ESLint, TypeScript, 434 tests, 70% backend coverage*
