### PR TITLE
fix(deploy): Explicitly install requirements.txt in Render build

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     env: python
     region: oregon
     plan: free
-    buildCommand: "pip install --upgrade pip && pip install -e ."
+    buildCommand: "pip install --upgrade pip && pip install -r requirements.txt && pip install -e ."
     startCommand: "python -m backend.main"
     healthCheckPath: /health
     envVars:


### PR DESCRIPTION
## Summary
- Fixed Render deployment not picking up `requirements.txt` changes
- Build command now explicitly runs `pip install -r requirements.txt` before `pip install -e .`
- This ensures `email-validator` (and any future requirements.txt changes) are installed

## Root Cause
Render was caching the old `.venv` and `pip install -e .` alone wasn't re-reading `requirements.txt` changes.

## Test plan
- [ ] CI passes
- [ ] Render deployment succeeds
- [ ] Health check returns healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)