### PR TITLE
fix(deps): Add explicit email-validator dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "pydantic[email]>=2.9.0",
+    "email-validator>=2.0.0",  # Explicit for Pydantic EmailStr
     "supabase>=2.0.0",
     "gunicorn>=21.0.0",
     "pillow>=10.0.0",  # Image optimization for uploads

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ uvicorn[standard]>=0.32.0
 python-dotenv>=1.0.0
 httpx>=0.27.0
 pydantic[email]>=2.9.0
+email-validator>=2.0.0
 supabase>=2.0.0
 gunicorn>=21.0.0
 pillow>=10.0.0


### PR DESCRIPTION
## Summary
- Adds explicit `email-validator>=2.0.0` dependency to both `requirements.txt` and `pyproject.toml`

## Problem
Backend was failing to start on Render with:
```
ImportError: email-validator is not installed, run `pip install 'pydantic[email]'`
```

The `pydantic[email]` extra wasn't properly installing `email-validator` on Render's build environment.

## Solution
Add `email-validator` as an explicit dependency to ensure it's always installed.

## Test plan
- [ ] CI passes
- [ ] Backend deploys successfully on Render
- [ ] `/api/v1/admin/*` endpoints work without ImportError

🤖 Generated with [Claude Code](https://claude.com/claude-code)