### PR TITLE
fix(router): Add missing /admin/analytics route

### DIFF
--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -91,6 +91,7 @@ export const router = createBrowserRouter([
     errorElement: <ErrorPage />,
     children: [
       { index: true, element: null },
+      { path: 'analytics', element: null },
       { path: 'users', element: null },
       { path: 'companies', element: null },
       { path: 'audit', element: null },


### PR DESCRIPTION
## Summary
- Adds the missing `/admin/analytics` route to `router.tsx`
- The analytics tab was added to AdminPortal.tsx (PR #132) but the corresponding route was never added
- This caused navigation to `/admin/analytics` to redirect to the hero page instead of showing the analytics dashboard

## Root Cause
The `ADMIN_TABS` array in `AdminPortal.tsx` includes `{ id: 'analytics', path: '/admin/analytics' }`, but the route children in `router.tsx` did not include `{ path: 'analytics', element: null }`.

## Test plan
- [ ] Navigate to https://axcouncil.ai/admin/analytics
- [ ] Verify analytics dashboard loads instead of redirecting to hero page
- [ ] Verify clicking Analytics tab in admin sidebar works

🤖 Generated with [Claude Code](https://claude.com/claude-code)