### PR TITLE
fix(stage1): Remove height ceiling from expanded card container

### DIFF
--- a/frontend/src/components/stage1/styles/Stage1BaseCard.css
+++ b/frontend/src/components/stage1/styles/Stage1BaseCard.css
@@ -42,8 +42,6 @@
   grid-column: 1 / -1;
   border-color: var(--color-blue-500);
   box-shadow: 0 4px 12px var(--stage1-shadow-color);
-  max-height: 500px;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
## Summary
Fixes Stage 2 and Stage 3 content being completely hidden by removing the `max-height: 500px` and `overflow: hidden` constraints from the `.stage1 .model-card.expanded` selector in Stage1BaseCard.css.

## What This Fixes
- Stage 2 and Stage 3 responses now display fully instead of being cut off
- Content scrolls properly within the expanded card
- No more content disappearing when cards expand

## Technical Details
The expanded card container had a 500px height limit with overflow hidden, which was preventing the full content from being visible even with the inner scrollable container fixed in the previous PR.

## Test Plan
- [ ] Expand a Stage 1 council response
- [ ] Verify Stage 2 content is visible below Stage 1
- [ ] Verify Stage 3 content is visible below Stage 2
- [ ] Scroll within expanded card to see full content
- [ ] Test on mobile and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)